### PR TITLE
Add Azure OpenAI configuration fields and models

### DIFF
--- a/apps/web/src/components/v2/token-usage.tsx
+++ b/apps/web/src/components/v2/token-usage.tsx
@@ -123,6 +123,17 @@ function getModelPricingPlaceholder(model: string): {
     },
 
     // OpenAI models (actual pricing - no caching support)
+    "openai:gpt-5": { inputPrice: 10.0, outputPrice: 40.0, cachePrice: 10.0 },
+    "openai:gpt-5-mini": {
+      inputPrice: 1.0,
+      outputPrice: 4.0,
+      cachePrice: 1.0,
+    },
+    "openai:gpt-5-nano": {
+      inputPrice: 0.2,
+      outputPrice: 0.8,
+      cachePrice: 0.2,
+    },
     "openai:o4": { inputPrice: 1.1, outputPrice: 4.4, cachePrice: 1.1 },
     "openai:o4-mini": { inputPrice: 1.1, outputPrice: 4.4, cachePrice: 1.1 },
     "openai:o3": { inputPrice: 2.0, outputPrice: 8.0, cachePrice: 2.0 },

--- a/packages/shared/src/open-swe/manager/index.ts
+++ b/packages/shared/src/open-swe/manager/index.ts
@@ -1,0 +1,2 @@
+export { GraphConfigurationMetadata } from "../types.js";
+export * from "./types.js";

--- a/packages/shared/src/open-swe/models.ts
+++ b/packages/shared/src/open-swe/models.ts
@@ -45,6 +45,18 @@ export const MODEL_OPTIONS = [
     value: "openai:gpt-5-nano",
   },
   {
+    label: "Azure GPT 5",
+    value: "azure-openai:gpt-5",
+  },
+  {
+    label: "Azure GPT 5 mini",
+    value: "azure-openai:gpt-5-mini",
+  },
+  {
+    label: "Azure GPT 5 nano",
+    value: "azure-openai:gpt-5-nano",
+  },
+  {
     label: "o4",
     value: "openai:o4",
   },
@@ -75,6 +87,22 @@ export const MODEL_OPTIONS = [
   {
     label: "GPT 4.1 mini",
     value: "openai:gpt-4.1-mini",
+  },
+  {
+    label: "Azure GPT 4o",
+    value: "azure-openai:gpt-4o",
+  },
+  {
+    label: "Azure GPT 4o mini",
+    value: "azure-openai:gpt-4o-mini",
+  },
+  {
+    label: "Azure GPT 4.1",
+    value: "azure-openai:gpt-4.1",
+  },
+  {
+    label: "Azure GPT 4.1 mini",
+    value: "azure-openai:gpt-4.1-mini",
   },
   {
     label: "Gemini 2.5 Pro",

--- a/packages/shared/src/open-swe/types.ts
+++ b/packages/shared/src/open-swe/types.ts
@@ -451,6 +451,26 @@ export const GraphConfigurationMetadata: {
       type: "hidden",
     },
   },
+  azureEndpoint: {
+    x_open_swe_ui_config: {
+      type: "text",
+      placeholder: "https://<resource>.openai.azure.com",
+      description: "Azure OpenAI endpoint URL",
+    },
+  },
+  azureApiVersion: {
+    x_open_swe_ui_config: {
+      type: "text",
+      default: "2024-08-01-preview",
+      description: "Azure OpenAI API version",
+    },
+  },
+  azureDeployment: {
+    x_open_swe_ui_config: {
+      type: "text",
+      description: "Azure OpenAI deployment name",
+    },
+  },
   apiKeys: {
     x_open_swe_ui_config: {
       type: "hidden",
@@ -638,11 +658,39 @@ export const GraphConfiguration = z.object({
     metadata: GraphConfigurationMetadata.reviewPullNumber,
   }),
   /**
+   * Azure OpenAI endpoint URL
+   */
+  azureEndpoint: withLangGraph(z.string().optional(), {
+    metadata: GraphConfigurationMetadata.azureEndpoint,
+  }),
+  /**
+   * Azure OpenAI API version
+   */
+  azureApiVersion: withLangGraph(z.string().optional(), {
+    metadata: GraphConfigurationMetadata.azureApiVersion,
+  }),
+  /**
+   * Azure OpenAI deployment name
+   */
+  azureDeployment: withLangGraph(z.string().optional(), {
+    metadata: GraphConfigurationMetadata.azureDeployment,
+  }),
+  /**
    * User defined API keys to use
    */
-  apiKeys: withLangGraph(z.record(z.string(), z.string()).optional(), {
-    metadata: GraphConfigurationMetadata.apiKeys,
-  }),
+  apiKeys: withLangGraph(
+    z
+      .object({
+        anthropicApiKey: z.string().optional(),
+        openaiApiKey: z.string().optional(),
+        googleApiKey: z.string().optional(),
+        azureApiKey: z.string().optional(),
+      })
+      .optional(),
+    {
+      metadata: GraphConfigurationMetadata.apiKeys,
+    },
+  ),
   /**
    * The user's GitHub access token. To be used in requests to get information about the user.
    */


### PR DESCRIPTION
## Summary
- add Azure endpoint, API version, deployment fields and azureApiKey support in shared types
- export GraphConfigurationMetadata from manager module so agent can access new fields
- list Azure OpenAI model options and GPT-5 variants with placeholder pricing

## Testing
- `yarn lint:fix --filter=@openswe/shared --filter=@openswe/web`
- `yarn format --filter=@openswe/shared --filter=@openswe/web`
- `yarn test --filter=@openswe/shared --filter=@openswe/web`

------
https://chatgpt.com/codex/tasks/task_e_68b080d9405c8327ac5e8a1fae3553ce