### PR TITLE
Add Azure provider support

### DIFF
--- a/apps/open-swe/src/utils/llms/model-manager.ts
+++ b/apps/open-swe/src/utils/llms/model-manager.ts
@@ -184,9 +184,9 @@ export class ModelManager {
 
     if (provider === "azure-openai") {
       const client = new AzureOpenAI({
-        api_key: apiKey ?? process.env.AZURE_OPENAI_API_KEY,
-        api_version: process.env.AZURE_OPENAI_API_VERSION,
-        azure_endpoint: process.env.AZURE_OPENAI_ENDPOINT,
+        apiKey: apiKey ?? process.env.AZURE_OPENAI_API_KEY,
+        apiVersion: process.env.AZURE_OPENAI_API_VERSION,
+        endpoint: process.env.AZURE_OPENAI_ENDPOINT,
       });
 
       logger.debug("Initializing model", {


### PR DESCRIPTION
## Summary
- add Azure OpenAI provider mappings in LLM nodes and ModelManager
- route provider-specific tools and messages based on configured model

## Testing
- `yarn lint:fix`
- `yarn format`
- `yarn build` *(fails: Failed to fetch `Inter` from Google Fonts)*
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68b0698a913c83279ccdf72611c86cf3