### PR TITLE
Bypass GitHub auth when disabled

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,10 +1,28 @@
 "use client";
 
 import { Toaster } from "@/components/ui/sonner";
-import React from "react";
+import React, { useEffect } from "react";
 import AuthStatus from "@/components/github/auth-status";
+import { useRouter } from "next/navigation";
 
 export default function Page(): React.ReactNode {
+  const router = useRouter();
+  const githubDisabled = process.env.NEXT_PUBLIC_GITHUB_DISABLED === "true";
+
+  useEffect(() => {
+    if (githubDisabled) {
+      router.replace("/chat");
+    }
+  }, [githubDisabled, router]);
+
+  if (githubDisabled) {
+    return (
+      <React.Suspense fallback={<div>Loading (layout)...</div>}>
+        <Toaster />
+      </React.Suspense>
+    );
+  }
+
   return (
     <React.Suspense fallback={<div>Loading (layout)...</div>}>
       <Toaster />

--- a/apps/web/src/components/github/auth-status.tsx
+++ b/apps/web/src/components/github/auth-status.tsx
@@ -45,10 +45,9 @@ function AuthStatusContent() {
 
   useEffect(() => {
     if (githubToken) {
-      console.log("redirecting to chat");
       router.push("/chat");
     }
-  }, [githubToken]);
+  }, [githubToken, router]);
 
   const checkAuthStatus = async () => {
     try {
@@ -185,6 +184,19 @@ function AuthStatusContent() {
 }
 
 export default function AuthStatus() {
+  const router = useRouter();
+  const githubDisabled = process.env.NEXT_PUBLIC_GITHUB_DISABLED === "true";
+
+  useEffect(() => {
+    if (githubDisabled) {
+      router.push("/chat");
+    }
+  }, [githubDisabled, router]);
+
+  if (githubDisabled) {
+    return null;
+  }
+
   return (
     <GitHubAppProvider>
       <AuthStatusContent />

--- a/apps/web/src/components/sidebar-buttons/index.tsx
+++ b/apps/web/src/components/sidebar-buttons/index.tsx
@@ -41,6 +41,7 @@ export const SidebarButtons = forwardRef<HTMLDivElement, SidebarButtonsProps>(
     };
 
     const isSidebarOpen = historyOpen || configOpen;
+    const githubDisabled = process.env.NEXT_PUBLIC_GITHUB_DISABLED === "true";
 
     return (
       <motion.div
@@ -106,7 +107,7 @@ export const SidebarButtons = forwardRef<HTMLDivElement, SidebarButtonsProps>(
             >
               <History className="size-5" />
             </TooltipIconButton>
-            <AuthStatus />
+            {!githubDisabled && <AuthStatus />}
           </div>
         </div>
       </motion.div>


### PR DESCRIPTION
## Summary
- Redirect to chat when `NEXT_PUBLIC_GITHUB_DISABLED` is true
- Hide GitHub auth status in sidebar when GitHub integration disabled
- Short-circuit AuthStatus component under disabled flag

## Testing
- `yarn lint:fix --filter=@openswe/web`
- `yarn format --filter=@openswe/web`
- `yarn test --filter=@openswe/web`


------
https://chatgpt.com/codex/tasks/task_e_68b76abfc6f483278d2c2cea93f1d413