### PR TITLE
feat(web): hide GitHub banner via env flag

### DIFF
--- a/apps/web/src/components/github/installation-banner.tsx
+++ b/apps/web/src/components/github/installation-banner.tsx
@@ -6,8 +6,17 @@ import { useState, useEffect } from "react";
 import { cn } from "@/lib/utils";
 
 const GITHUB_INSTALLATION_SEEN_KEY = "github_installation_seen";
+const GITHUB_DISABLED = process.env.NEXT_PUBLIC_GITHUB_DISABLED === "true";
 
 export function GitHubInstallationBanner() {
+  if (GITHUB_DISABLED) {
+    return null;
+  }
+
+  return <GitHubInstallationBannerContent />;
+}
+
+function GitHubInstallationBannerContent() {
   const { isInstalled, isLoading } = useGitHubAppProvider();
   const [dismissed, setDismissed] = useState(false);
   const [isNewUser, setIsNewUser] = useState(false);


### PR DESCRIPTION
## Summary
- allow disabling GitHub installation banner with NEXT_PUBLIC_GITHUB_DISABLED
- short-circuit banner rendering when disabled

## Testing
- `yarn lint:fix`
- `yarn format`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68b76bcfca1c832788d11db1db6d976d