### PR TITLE
feat: bypass GitHub auth when disabled

### DIFF
--- a/apps/web/src/app/api/auth/status/route.ts
+++ b/apps/web/src/app/api/auth/status/route.ts
@@ -6,6 +6,10 @@ import { isAuthenticated } from "@/lib/auth";
  */
 export async function GET(request: NextRequest) {
   try {
+    if (process.env.NEXT_PUBLIC_GITHUB_DISABLED === "true") {
+      return NextResponse.json({ authenticated: true });
+    }
+
     const authenticated = isAuthenticated(request);
     return NextResponse.json({ authenticated });
   } catch (error) {

--- a/apps/web/src/components/github/auth-status.tsx
+++ b/apps/web/src/components/github/auth-status.tsx
@@ -14,6 +14,7 @@ function AuthStatusContent() {
   const router = useRouter();
   const [isAuth, setIsAuth] = useState<boolean | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const githubDisabled = process.env.NEXT_PUBLIC_GITHUB_DISABLED === "true";
 
   const {
     token: githubToken,
@@ -51,6 +52,10 @@ function AuthStatusContent() {
 
   const checkAuthStatus = async () => {
     try {
+      if (githubDisabled) {
+        setIsAuth(true);
+        return;
+      }
       const response = await fetch("/api/auth/status");
       const data = await response.json();
       setIsAuth(data.authenticated);


### PR DESCRIPTION
## Summary
- Treat auth status as authenticated when NEXT_PUBLIC_GITHUB_DISABLED is true
- Short-circuit AuthStatus client check when GitHub integration disabled

## Testing
- `yarn lint:fix --filter=@openswe/web` *(fails: The Next.js plugin was not detected in your ESLint configuration)*
- `yarn format --filter=@openswe/web`
- `yarn test --filter=@openswe/web`


------
https://chatgpt.com/codex/tasks/task_e_68b76d54b0f08327a83b4be3e1495d1d