### PR TITLE
refactor: introduce session helpers

### DIFF
--- a/apps/web/src/app/api/auth/logout/route.ts
+++ b/apps/web/src/app/api/auth/logout/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { clearGitHubToken } from "@/lib/auth";
+import { clearSession } from "@/lib/auth";
 
 /**
  * API route to handle GitHub logout
@@ -7,10 +7,9 @@ import { clearGitHubToken } from "@/lib/auth";
 export async function POST(request: NextRequest) {
   try {
     const response = NextResponse.json({ success: true });
-    clearGitHubToken(response);
+    clearSession(response);
     return response;
-  } catch (error) {
-    console.error("Error during logout:", error);
+  } catch {
     return NextResponse.json(
       { success: false, error: "Failed to logout" },
       { status: 500 },

--- a/apps/web/src/app/api/auth/status/route.ts
+++ b/apps/web/src/app/api/auth/status/route.ts
@@ -5,15 +5,13 @@ import { isAuthenticated } from "@/lib/auth";
  * API route to check GitHub authentication status
  */
 export async function GET(request: NextRequest) {
+  if (process.env.NEXT_PUBLIC_GITHUB_DISABLED === "true") {
+    return NextResponse.json({ authenticated: true });
+  }
   try {
-    if (process.env.NEXT_PUBLIC_GITHUB_DISABLED === "true") {
-      return NextResponse.json({ authenticated: true });
-    }
-
     const authenticated = isAuthenticated(request);
     return NextResponse.json({ authenticated });
-  } catch (error) {
-    console.error("Error checking auth status:", error);
+  } catch {
     return NextResponse.json(
       { authenticated: false, error: "Failed to check authentication status" },
       { status: 500 },

--- a/apps/web/src/app/api/auth/user/route.ts
+++ b/apps/web/src/app/api/auth/user/route.ts
@@ -1,31 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getGitHubToken } from "@/lib/auth";
-import { verifyGithubUser } from "@openswe/shared/github/verify-user";
+import { getSession } from "@/lib/auth";
 
 export async function GET(request: NextRequest) {
   try {
-    const token = getGitHubToken(request);
-    if (!token || !token.access_token) {
+    const session = getSession(request);
+    if (!session) {
       return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
     }
-    const user = await verifyGithubUser(token.access_token);
-    if (!user) {
-      return NextResponse.json(
-        { error: "Invalid GitHub token" },
-        { status: 401 },
-      );
-    }
-    // Only return safe fields
-    return NextResponse.json({
-      user: {
-        login: user.login,
-        avatar_url: user.avatar_url,
-        html_url: user.html_url,
-        name: user.name,
-        email: user.email,
-      },
-    });
-  } catch (error) {
+    return NextResponse.json({ user: session.user });
+  } catch {
     return NextResponse.json(
       { error: "Failed to fetch user info" },
       { status: 500 },

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -1,125 +1,71 @@
 import { NextRequest, NextResponse } from "next/server";
-import {
-  GITHUB_TOKEN_COOKIE,
-  GITHUB_TOKEN_TYPE_COOKIE,
-  GITHUB_INSTALLATION_ID_COOKIE,
-} from "@openswe/shared/constants";
+import jsonwebtoken from "jsonwebtoken";
+import { SESSION_COOKIE } from "@openswe/shared/constants";
 
 export const GITHUB_INSTALLATION_STATE_COOKIE = "github_installation_state";
 export const GITHUB_INSTALLATION_RETURN_TO_COOKIE = "installation_return_to";
 
-export interface GitHubTokenData {
-  access_token: string;
-  token_type: string;
-  installation_id?: string;
+export interface SessionUser {
+  login: string;
+  avatar_url: string;
+  html_url: string;
+  name: string | null;
+  email: string | null;
 }
 
-/**
- * Cookie options for GitHub token cookies
- */
+export interface SessionData {
+  accessToken: string;
+  tokenType: string;
+  installationId?: string;
+  user: SessionUser;
+}
+
+const SESSION_SECRET = process.env.SESSION_SECRET || "development-secret";
+
 function getCookieOptions(expires?: Date) {
   return {
     httpOnly: true,
     secure: process.env.NODE_ENV === "production",
     sameSite: "lax" as const,
-    maxAge: expires ? undefined : 60 * 60 * 24 * 30, // 30 days
+    maxAge: expires ? undefined : 60 * 60 * 24 * 30,
     expires,
     path: "/",
   };
 }
 
-/**
- * Cookie options for GitHub installation ID cookie (non-HTTP-only for client access)
- */
 export function getInstallationCookieOptions(expires?: Date) {
   return {
     secure: process.env.NODE_ENV === "production",
     sameSite: "lax" as const,
-    maxAge: expires ? undefined : 60 * 60 * 24 * 30, // 30 days
+    maxAge: expires ? undefined : 60 * 60 * 24 * 30,
     expires,
     path: "/",
   };
 }
 
-/**
- * Stores GitHub OAuth token data in secure HTTP-only cookies
- *
- * @param tokenData The GitHub token data to store
- * @param response NextResponse to set cookies on
- */
-export function storeGitHubToken(
-  tokenData: GitHubTokenData,
-  response: NextResponse,
-): void {
-  const cookieOptions = getCookieOptions();
-
-  // Store token components in separate cookies for better security
-  response.cookies.set(
-    GITHUB_TOKEN_COOKIE,
-    tokenData.access_token,
-    cookieOptions,
-  );
-  response.cookies.set(
-    GITHUB_TOKEN_TYPE_COOKIE,
-    tokenData.token_type || "bearer",
-    cookieOptions,
-  );
-
-  // Store installation ID if provided
-  if (tokenData.installation_id) {
-    response.cookies.set(
-      GITHUB_INSTALLATION_ID_COOKIE,
-      tokenData.installation_id,
-      getInstallationCookieOptions(),
-    );
-  }
+export function createSession(data: SessionData, response: NextResponse): void {
+  const token = jsonwebtoken.sign(data, SESSION_SECRET, {
+    expiresIn: "30d",
+  });
+  response.cookies.set(SESSION_COOKIE, token, getCookieOptions());
 }
 
-/**
- * Retrieves GitHub OAuth token data from cookies
- *
- * @param request NextRequest to get cookies from
- */
-export function getGitHubToken(request: NextRequest): GitHubTokenData | null {
+export function getSession(request: NextRequest): SessionData | null {
+  const token = request.cookies.get(SESSION_COOKIE)?.value;
+  if (!token) {
+    return null;
+  }
   try {
-    const accessToken = request.cookies.get(GITHUB_TOKEN_COOKIE)?.value;
-    const tokenType = request.cookies.get(GITHUB_TOKEN_TYPE_COOKIE)?.value;
-    const installationId = request.cookies.get(
-      GITHUB_INSTALLATION_ID_COOKIE,
-    )?.value;
-
-    if (!accessToken) {
-      return null;
-    }
-
-    return {
-      access_token: accessToken,
-      token_type: tokenType || "bearer",
-      installation_id: installationId,
-    };
-  } catch (error) {
-    console.error("Error retrieving GitHub token:", error);
+    return jsonwebtoken.verify(token, SESSION_SECRET) as SessionData;
+  } catch {
     return null;
   }
 }
 
-/**
- * Removes GitHub OAuth token data from cookies (logout)
- *
- * @param response NextResponse to set cookies on
- */
-export function clearGitHubToken(response: NextResponse): void {
-  response.cookies.delete(GITHUB_TOKEN_COOKIE);
-  response.cookies.delete(GITHUB_TOKEN_TYPE_COOKIE);
-  response.cookies.delete(GITHUB_INSTALLATION_ID_COOKIE);
+export function clearSession(response: NextResponse): void {
+  response.cookies.delete(SESSION_COOKIE);
 }
 
-/**
- * Checks if user has a valid GitHub token
- *
- * @param request NextRequest to get cookies from
- */
 export function isAuthenticated(request: NextRequest): boolean {
-  const token = getGitHubToken(request);
-  return token !== null && token.access_token.length > 0;
+  return getSession(request) !== null;
 }

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -15,7 +15,7 @@ export const LOCAL_MODE_HEADER = "x-local-mode";
 export const DO_NOT_RENDER_ID_PREFIX = "do-not-render-";
 export const GITHUB_AUTH_STATE_COOKIE = "github_auth_state";
 export const GITHUB_INSTALLATION_ID_COOKIE = "github_installation_id";
-export const GITHUB_TOKEN_TYPE_COOKIE = "github_token_type";
+export const SESSION_COOKIE = "session";
 
 export const OPEN_SWE_V2_GRAPH_ID = "open-swe-v2";
 export const MANAGER_GRAPH_ID = "manager";


### PR DESCRIPTION
## Summary
- switch to JWT-based session helpers and drop GitHub token utilities
- update auth endpoints to use generic sessions
- remove unused GITHUB_TOKEN_TYPE_COOKIE constant

## Testing
- `yarn lint:fix`
- `yarn format`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68b85fa4eb3883279f3a17fe41bc13aa