### PR TITLE
feat: centralize GitHub enable flag

### DIFF
--- a/apps/open-swe/src/routes/app.ts
+++ b/apps/open-swe/src/routes/app.ts
@@ -1,6 +1,9 @@
 import { Hono } from "hono";
-import { unifiedWebhookHandler } from "./github/unified-webhook.js";
+import { ENABLE_GITHUB } from "@openswe/shared/config";
 
 export const app = new Hono();
 
-app.post("/webhooks/github", unifiedWebhookHandler);
+if (ENABLE_GITHUB) {
+  const { unifiedWebhookHandler } = await import("./github/unified-webhook.js");
+  app.post("/webhooks/github", unifiedWebhookHandler);
+}

--- a/apps/web/.env.local
+++ b/apps/web/.env.local
@@ -28,8 +28,8 @@ LANGGRAPH_API_URL="http://localhost:2024"
 # encrypted in the web app can be decrypted in the agent.
 SECRETS_ENCRYPTION_KEY=""
 
-# Disable GitHub integration when set to "true"
-NEXT_PUBLIC_GITHUB_DISABLED="true"
+# Enable GitHub integration when set to "true"
+ENABLE_GITHUB="false"
 
 # List of GitHub usernames that are allowed to use Open SWE without providing API keys
 # This is only used in production. In development every user is an "allowed user".

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -6,7 +6,7 @@ const nextConfig = {
     },
   },
   env: {
-    NEXT_PUBLIC_GITHUB_DISABLED: process.env.NEXT_PUBLIC_GITHUB_DISABLED,
+    ENABLE_GITHUB: process.env.ENABLE_GITHUB,
   },
 };
 

--- a/apps/web/src/app/api/auth/status/route.ts
+++ b/apps/web/src/app/api/auth/status/route.ts
@@ -1,11 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import { isAuthenticated } from "@/lib/auth";
+import { ENABLE_GITHUB } from "@openswe/shared/config";
 
 /**
  * API route to check GitHub authentication status
  */
 export async function GET(request: NextRequest) {
-  if (process.env.NEXT_PUBLIC_GITHUB_DISABLED === "true") {
+  if (!ENABLE_GITHUB) {
     return NextResponse.json({ authenticated: true });
   }
   try {

--- a/apps/web/src/app/api/github/installation-callback/route.ts
+++ b/apps/web/src/app/api/github/installation-callback/route.ts
@@ -5,13 +5,14 @@ import {
   getInstallationCookieOptions,
 } from "@/lib/auth";
 import { NextRequest, NextResponse } from "next/server";
+import { ENABLE_GITHUB } from "@openswe/shared/config";
 
 /**
  * Handles callbacks from GitHub App installations
  * This endpoint is called by GitHub after a user installs or configures the GitHub App
  */
 export async function GET(request: NextRequest) {
-  if (process.env.NEXT_PUBLIC_GITHUB_DISABLED === "true") {
+  if (!ENABLE_GITHUB) {
     return NextResponse.json(
       { error: "GitHub integration disabled" },
       { status: 404 },

--- a/apps/web/src/app/api/github/installation/route.ts
+++ b/apps/web/src/app/api/github/installation/route.ts
@@ -5,6 +5,7 @@ import {
 import { NextRequest, NextResponse } from "next/server";
 import { randomBytes } from "crypto";
 import { GITHUB_TOKEN_COOKIE } from "@openswe/shared/constants";
+import { ENABLE_GITHUB } from "@openswe/shared/config";
 
 /**
  * Initiates the GitHub App installation flow
@@ -12,7 +13,7 @@ import { GITHUB_TOKEN_COOKIE } from "@openswe/shared/constants";
  * select which repositories to grant access to
  */
 export async function GET(request: NextRequest) {
-  if (process.env.NEXT_PUBLIC_GITHUB_DISABLED === "true") {
+  if (!ENABLE_GITHUB) {
     return NextResponse.json(
       { error: "GitHub integration disabled" },
       { status: 404 },

--- a/apps/web/src/app/api/github/installations/route.ts
+++ b/apps/web/src/app/api/github/installations/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSession } from "@/lib/auth";
 import { Endpoints } from "@octokit/types";
+import { ENABLE_GITHUB } from "@openswe/shared/config";
 
 type GitHubInstallationsResponse =
   Endpoints["GET /user/installations"]["response"]["data"];
@@ -10,7 +11,7 @@ type GitHubInstallationsResponse =
  * Uses the user's access token from GITHUB_TOKEN_COOKIE to call GET /user/installations
  */
 export async function GET(request: NextRequest) {
-  if (process.env.NEXT_PUBLIC_GITHUB_DISABLED === "true") {
+  if (!ENABLE_GITHUB) {
     return NextResponse.json(
       { error: "GitHub integration disabled" },
       { status: 404 },

--- a/apps/web/src/app/api/github/proxy/[..._path]/route.ts
+++ b/apps/web/src/app/api/github/proxy/[..._path]/route.ts
@@ -1,11 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getInstallationToken } from "@openswe/shared/github/auth";
 import { GITHUB_INSTALLATION_ID_COOKIE } from "@openswe/shared/constants";
+import { ENABLE_GITHUB } from "@openswe/shared/config";
 
 const GITHUB_API_URL = "https://api.github.com";
 
 async function handler(req: NextRequest) {
-  if (process.env.NEXT_PUBLIC_GITHUB_DISABLED === "true") {
+  if (!ENABLE_GITHUB) {
     return NextResponse.json(
       { error: "GitHub integration disabled" },
       { status: 404 },

--- a/apps/web/src/app/api/github/repositories/route.ts
+++ b/apps/web/src/app/api/github/repositories/route.ts
@@ -2,13 +2,14 @@ import { NextRequest, NextResponse } from "next/server";
 import { getInstallationToken } from "@openswe/shared/github/auth";
 import { getInstallationRepositories, Repository } from "@/utils/github";
 import { GITHUB_INSTALLATION_ID_COOKIE } from "@openswe/shared/constants";
+import { ENABLE_GITHUB } from "@openswe/shared/config";
 
 /**
  * Fetches repositories accessible to the GitHub App installation
  * Requires a valid GitHub installation ID in the cookies. Supports pagination via 'page' query parameter.
  */
 export async function GET(request: NextRequest) {
-  if (process.env.NEXT_PUBLIC_GITHUB_DISABLED === "true") {
+  if (!ENABLE_GITHUB) {
     return NextResponse.json(
       { error: "GitHub integration disabled" },
       { status: 404 },

--- a/apps/web/src/app/api/github/switch-installation/route.ts
+++ b/apps/web/src/app/api/github/switch-installation/route.ts
@@ -1,12 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import { GITHUB_INSTALLATION_ID_COOKIE } from "@openswe/shared/constants";
 import { getInstallationCookieOptions } from "@/lib/auth";
+import { ENABLE_GITHUB } from "@openswe/shared/config";
 
 /**
  * Updates the current GitHub installation ID in the cookie
  */
 export async function POST(request: NextRequest) {
-  if (process.env.NEXT_PUBLIC_GITHUB_DISABLED === "true") {
+  if (!ENABLE_GITHUB) {
     return NextResponse.json(
       { error: "GitHub integration disabled" },
       { status: 404 },

--- a/apps/web/src/app/api/github/token/route.ts
+++ b/apps/web/src/app/api/github/token/route.ts
@@ -1,13 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getInstallationToken } from "@openswe/shared/github/auth";
 import { GITHUB_INSTALLATION_ID_COOKIE } from "@openswe/shared/constants";
+import { ENABLE_GITHUB } from "@openswe/shared/config";
 
 /**
  * Returns a GitHub installation token that can be used for Git operations
  * This endpoint is intended for internal use by the AI coding agent
  */
 export async function GET(request: NextRequest) {
-  if (process.env.NEXT_PUBLIC_GITHUB_DISABLED === "true") {
+  if (!ENABLE_GITHUB) {
     return NextResponse.json(
       { error: "GitHub integration disabled" },
       { status: 404 },

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -4,10 +4,11 @@ import { Toaster } from "@/components/ui/sonner";
 import React, { useEffect } from "react";
 import AuthStatus from "@/components/github/auth-status";
 import { useRouter } from "next/navigation";
+import { ENABLE_GITHUB } from "@openswe/shared/config";
 
 export default function Page(): React.ReactNode {
   const router = useRouter();
-  const githubDisabled = process.env.NEXT_PUBLIC_GITHUB_DISABLED === "true";
+  const githubDisabled = !ENABLE_GITHUB;
 
   useEffect(() => {
     if (githubDisabled) {

--- a/apps/web/src/components/github/auth-status.tsx
+++ b/apps/web/src/components/github/auth-status.tsx
@@ -9,12 +9,13 @@ import { useGitHubToken } from "@/hooks/useGitHubToken";
 import { useGitHubAppProvider } from "@/providers/GitHubApp";
 import { GitHubAppProvider } from "@/providers/GitHubApp";
 import { useRouter } from "next/navigation";
+import { ENABLE_GITHUB } from "@openswe/shared/config";
 
 function AuthStatusContent() {
   const router = useRouter();
   const [isAuth, setIsAuth] = useState<boolean | null>(null);
   const [isLoading, setIsLoading] = useState(false);
-  const githubDisabled = process.env.NEXT_PUBLIC_GITHUB_DISABLED === "true";
+  const githubDisabled = !ENABLE_GITHUB;
 
   const {
     token: githubToken,
@@ -190,7 +191,7 @@ function AuthStatusContent() {
 
 export default function AuthStatus() {
   const router = useRouter();
-  const githubDisabled = process.env.NEXT_PUBLIC_GITHUB_DISABLED === "true";
+  const githubDisabled = !ENABLE_GITHUB;
 
   useEffect(() => {
     if (githubDisabled) {

--- a/apps/web/src/components/github/installation-banner.tsx
+++ b/apps/web/src/components/github/installation-banner.tsx
@@ -4,9 +4,10 @@ import { useGitHubAppProvider } from "@/providers/GitHubApp";
 import { InstallationPrompt } from "./installation-prompt";
 import { useState, useEffect } from "react";
 import { cn } from "@/lib/utils";
+import { ENABLE_GITHUB } from "@openswe/shared/config";
 
 const GITHUB_INSTALLATION_SEEN_KEY = "github_installation_seen";
-const GITHUB_DISABLED = process.env.NEXT_PUBLIC_GITHUB_DISABLED === "true";
+const GITHUB_DISABLED = !ENABLE_GITHUB;
 
 export function GitHubInstallationBanner() {
   if (GITHUB_DISABLED) {

--- a/apps/web/src/components/github/repo-branch-selectors/index.tsx
+++ b/apps/web/src/components/github/repo-branch-selectors/index.tsx
@@ -1,8 +1,9 @@
 import { BranchSelector } from "./branch-selector";
 import { RepositorySelector } from "./repository-selector";
 import { useQueryState } from "nuqs";
+import { ENABLE_GITHUB } from "@openswe/shared/config";
 
-const GITHUB_DISABLED = process.env.NEXT_PUBLIC_GITHUB_DISABLED === "true";
+const GITHUB_DISABLED = !ENABLE_GITHUB;
 
 export function RepositoryBranchSelectors() {
   const [threadId] = useQueryState("threadId");

--- a/apps/web/src/components/github/repo-branch-selectors/repository-selector.tsx
+++ b/apps/web/src/components/github/repo-branch-selectors/repository-selector.tsx
@@ -20,8 +20,9 @@ import { GitHubSVG } from "@/components/icons/github";
 import { Repository } from "@/utils/github";
 import { useGitHubAppProvider } from "@/providers/GitHubApp";
 import { useLocalRepositories } from "@/hooks/useLocalRepositories";
+import { ENABLE_GITHUB } from "@openswe/shared/config";
 
-const GITHUB_DISABLED = process.env.NEXT_PUBLIC_GITHUB_DISABLED === "true";
+const GITHUB_DISABLED = !ENABLE_GITHUB;
 
 interface RepositorySelectorProps {
   disabled?: boolean;

--- a/apps/web/src/components/sidebar-buttons/index.tsx
+++ b/apps/web/src/components/sidebar-buttons/index.tsx
@@ -10,6 +10,7 @@ import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { TooltipIconButton } from "@/components/ui/tooltip-icon-button";
 import AuthStatus from "@/components/github/auth-status";
+import { ENABLE_GITHUB } from "@openswe/shared/config";
 
 interface SidebarButtonsProps {
   historyOpen: boolean;
@@ -41,7 +42,7 @@ export const SidebarButtons = forwardRef<HTMLDivElement, SidebarButtonsProps>(
     };
 
     const isSidebarOpen = historyOpen || configOpen;
-    const githubDisabled = process.env.NEXT_PUBLIC_GITHUB_DISABLED === "true";
+    const githubDisabled = !ENABLE_GITHUB;
 
     return (
       <motion.div

--- a/apps/web/src/features/settings-page/index.tsx
+++ b/apps/web/src/features/settings-page/index.tsx
@@ -11,8 +11,9 @@ import { GitHubAppProvider } from "@/providers/GitHubApp";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { ENABLE_GITHUB } from "@openswe/shared/config";
 
-const GITHUB_DISABLED = process.env.NEXT_PUBLIC_GITHUB_DISABLED === "true";
+const GITHUB_DISABLED = !ENABLE_GITHUB;
 
 export default function SettingsPage() {
   const router = useRouter();

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -4,8 +4,9 @@ import {
   GITHUB_INSTALLATION_ID_COOKIE,
 } from "@openswe/shared/constants";
 import { verifyGithubUser } from "@openswe/shared/github/verify-user";
+import { ENABLE_GITHUB } from "@openswe/shared/config";
 
-const GITHUB_DISABLED = process.env.NEXT_PUBLIC_GITHUB_DISABLED === "true";
+const GITHUB_DISABLED = !ENABLE_GITHUB;
 
 export async function middleware(request: NextRequest) {
   if (GITHUB_DISABLED) {

--- a/apps/web/src/providers/GitHubApp.tsx
+++ b/apps/web/src/providers/GitHubApp.tsx
@@ -3,8 +3,7 @@
 import { useGitHubApp } from "@/hooks/useGitHubApp";
 import { createContext, useContext, ReactNode, useState } from "react";
 import type { TargetRepository } from "@openswe/shared/open-swe/types";
-
-const GITHUB_DISABLED = process.env.NEXT_PUBLIC_GITHUB_DISABLED === "true";
+import { ENABLE_GITHUB } from "@openswe/shared/config";
 
 type GitHubAppContextType = ReturnType<typeof useGitHubApp>;
 
@@ -15,7 +14,7 @@ const GitHubAppContext = createContext<GitHubAppContextType | undefined>(
 export function GitHubAppProvider({ children }: { children: ReactNode }) {
   const [localSelectedRepository, setLocalSelectedRepository] =
     useState<TargetRepository | null>(null);
-  if (GITHUB_DISABLED) {
+  if (!ENABLE_GITHUB) {
     const finalValue: GitHubAppContextType = {
       isInstalled: null,
       isLoading: false,

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -1,0 +1,1 @@
+export const ENABLE_GITHUB = process.env.ENABLE_GITHUB !== "false";

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -1,3 +1,5 @@
+import { ENABLE_GITHUB } from "./config";
+
 export const TIMEOUT_SEC = 60; // 1 minute
 export const SANDBOX_ROOT_DIR = "/home/daytona";
 export const DAYTONA_IMAGE_NAME = "daytonaio/langchain-open-swe:0.1.0";
@@ -6,15 +8,25 @@ export const PLAN_INTERRUPT_DELIMITER = ":::";
 export const PLAN_INTERRUPT_ACTION_TITLE = "Approve/Edit Plan";
 
 // Prefix the access token with `x-` so that it's included in requests to the LangGraph server.
-export const GITHUB_TOKEN_COOKIE = "x-github-access-token";
-export const GITHUB_INSTALLATION_TOKEN_COOKIE = "x-github-installation-token";
-export const GITHUB_INSTALLATION_NAME = "x-github-installation-name";
-export const GITHUB_PAT = "x-github-pat";
-export const GITHUB_INSTALLATION_ID = "x-github-installation-id";
+export const GITHUB_TOKEN_COOKIE = ENABLE_GITHUB ? "x-github-access-token" : "";
+export const GITHUB_INSTALLATION_TOKEN_COOKIE = ENABLE_GITHUB
+  ? "x-github-installation-token"
+  : "";
+export const GITHUB_INSTALLATION_NAME = ENABLE_GITHUB
+  ? "x-github-installation-name"
+  : "";
+export const GITHUB_PAT = ENABLE_GITHUB ? "x-github-pat" : "";
+export const GITHUB_INSTALLATION_ID = ENABLE_GITHUB
+  ? "x-github-installation-id"
+  : "";
 export const LOCAL_MODE_HEADER = "x-local-mode";
 export const DO_NOT_RENDER_ID_PREFIX = "do-not-render-";
-export const GITHUB_AUTH_STATE_COOKIE = "github_auth_state";
-export const GITHUB_INSTALLATION_ID_COOKIE = "github_installation_id";
+export const GITHUB_AUTH_STATE_COOKIE = ENABLE_GITHUB
+  ? "github_auth_state"
+  : "";
+export const GITHUB_INSTALLATION_ID_COOKIE = ENABLE_GITHUB
+  ? "github_installation_id"
+  : "";
 export const SESSION_COOKIE = "session";
 
 export const OPEN_SWE_V2_GRAPH_ID = "open-swe-v2";
@@ -22,8 +34,10 @@ export const MANAGER_GRAPH_ID = "manager";
 export const PLANNER_GRAPH_ID = "planner";
 export const PROGRAMMER_GRAPH_ID = "programmer";
 
-export const GITHUB_USER_ID_HEADER = "x-github-user-id";
-export const GITHUB_USER_LOGIN_HEADER = "x-github-user-login";
+export const GITHUB_USER_ID_HEADER = ENABLE_GITHUB ? "x-github-user-id" : "";
+export const GITHUB_USER_LOGIN_HEADER = ENABLE_GITHUB
+  ? "x-github-user-login"
+  : "";
 
 export const DEFAULT_MCP_SERVERS = {
   "langgraph-docs-mcp": {


### PR DESCRIPTION
## Summary
- add shared `ENABLE_GITHUB` flag
- wrap GitHub webhook route behind flag
- replace `NEXT_PUBLIC_GITHUB_DISABLED` checks across web app

## Testing
- `yarn lint:fix`
- `yarn format`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68b865358e988327aa517d2d5bb185df