### PR TITLE
fix shared config import path

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -1,4 +1,4 @@
-import { ENABLE_GITHUB } from "./config";
+import { ENABLE_GITHUB } from "./config.js";
 
 export const TIMEOUT_SEC = 60; // 1 minute
 export const SANDBOX_ROOT_DIR = "/home/daytona";


### PR DESCRIPTION
## Summary
- fix `@openswe/shared` constants to import config with explicit `.js` extension for NodeNext builds

## Testing
- `yarn lint:fix --filter=@openswe/shared`
- `yarn format --filter=@openswe/shared`
- `yarn test --filter=@openswe/shared`
- `yarn workspace @openswe/shared build`
- `yarn workspace @openswe/agent dev`

------
https://chatgpt.com/codex/tasks/task_e_68b8700073348327a8561b96433f422f