### PR TITLE
refactor(web): remove github issue check from thread view

### DIFF
--- a/apps/web/src/components/v2/thread-view.tsx
+++ b/apps/web/src/components/v2/thread-view.tsx
@@ -112,14 +112,6 @@ export function ThreadView({
     });
 
   const [errorState, setErrorState] = useState<ErrorState | null>(null);
-  const [hasGitHubIssue, setHasGitHubIssue] = useState(false);
-
-  useEffect(() => {
-    stream.client.threads.get(displayThread.id).then((thread) => {
-      const configurable = (thread as Record<string, any>).config?.configurable;
-      setHasGitHubIssue(!!configurable?.shouldCreateIssue);
-    });
-  }, [displayThread.id]);
 
   // Load optimistic message from sessionStorage
   useEffect(() => {
@@ -354,9 +346,8 @@ export function ThreadView({
       ]
     : filteredMessages;
 
-  const shouldDisableManagerInput = !hasGitHubIssue
-    ? stream.isLoading || plannerStream.isLoading || programmerStream.isLoading
-    : false;
+  const shouldDisableManagerInput =
+    stream.isLoading || plannerStream.isLoading || programmerStream.isLoading;
 
   return (
     <div className="bg-background flex h-screen flex-1 flex-col">


### PR DESCRIPTION
## Summary
- drop github issue gating logic in thread view
- disable manager input based solely on local thread state

## Testing
- `yarn format --filter=@openswe/web`
- `yarn lint --filter=@openswe/web`
- `yarn test --filter=@openswe/web`


------
https://chatgpt.com/codex/tasks/task_e_68bf7672986483279ea34345b343e33e