### PR TITLE
fix build by avoiding external fonts

### DIFF
--- a/apps/web/src/app/(v2)/chat/[thread_id]/page.tsx
+++ b/apps/web/src/app/(v2)/chat/[thread_id]/page.tsx
@@ -56,7 +56,6 @@ export default function ThreadPage({
 
   const { threads, isLoading: threadsLoading } = useThreadsSWR({
     assistantId: MANAGER_GRAPH_ID,
-    disableOrgFiltering: true,
   });
 
   // Find the thread by ID

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,15 +1,8 @@
 import type { Metadata } from "next";
 import "./globals.css";
-import { Inter } from "next/font/google";
 import React from "react";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
 import { ThemeProvider } from "@/components/theme-provider";
-
-const inter = Inter({
-  subsets: ["latin"],
-  preload: true,
-  display: "swap",
-});
 
 export const metadata: Metadata = {
   title: "Open SWE",
@@ -57,7 +50,7 @@ export default function RootLayout({
           }}
         />
       </head>
-      <body className={inter.className}>
+      <body className="font-sans">
         <ThemeProvider
           defaultTheme="system"
           storageKey="theme"

--- a/apps/web/src/components/v2/thread-switcher.tsx
+++ b/apps/web/src/components/v2/thread-switcher.tsx
@@ -29,7 +29,6 @@ export function ThreadSwitcher({ currentThread }: ThreadSwitcherProps) {
 
   const { threads, isLoading: threadsLoading } = useThreadsSWR({
     assistantId: MANAGER_GRAPH_ID,
-    disableOrgFiltering: true,
   });
 
   const threadsMetadata = useMemo(() => threadsToMetadata(threads), [threads]);


### PR DESCRIPTION
## Summary
- use system font instead of Google-hosted Inter to prevent build-time network failure
- remove obsolete `disableOrgFiltering` option when fetching threads

## Testing
- `yarn lint:fix`
- `yarn format`
- `yarn test`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68bf79640c648327b689e1f8a8884711