### PR TITLE
feat(web): provider-agnostic pull request messaging

### DIFF
--- a/apps/web/src/components/gen-ui/pull-request-opened.tsx
+++ b/apps/web/src/components/gen-ui/pull-request-opened.tsx
@@ -98,7 +98,7 @@ export function PullRequestOpened({
       case "loading":
         return "Preparing to open pull request...";
       case "generating":
-        return "Opening pull request on GitHub...";
+        return "Opening pull request...";
       case "done":
         return branch ? `${branch} → ${targetBranch}` : "Successfully opened";
     }
@@ -154,7 +154,7 @@ export function PullRequestOpened({
                 href={url}
                 target="_blank"
                 rel="noopener noreferrer"
-                title="Open pull request on GitHub"
+                title="Open pull request"
               >
                 <ExternalLink className="h-4 w-4" />
               </a>


### PR DESCRIPTION
## Summary
- remove GitHub-specific wording when opening pull requests
- update pull-request link tooltip with provider-agnostic text

## Testing
- `yarn lint:fix`
- `yarn format`
- `yarn test`
- `node --experimental-vm-modules ../../node_modules/jest/bin/jest.js --config jest.config.js --testPathPattern=int.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68bf7df0a09483279621be4a011e5674