### PR TITLE
refactor: remove github references from web ui

### DIFF
--- a/apps/web/src/app/api/[..._path]/route.ts
+++ b/apps/web/src/app/api/[..._path]/route.ts
@@ -2,7 +2,7 @@ import { initApiPassthrough } from "langgraph-nextjs-api-passthrough";
 import { encryptSecret } from "@openswe/shared/crypto";
 
 // This file acts as a proxy for requests to your LangGraph server.
-// Read the [Going to Production](https://github.com/langchain-ai/agent-chat-ui?tab=readme-ov-file#going-to-production) section for more information.
+// Read the Going to Production section of the documentation for more information.
 
 export const { GET, POST, PUT, PATCH, DELETE, OPTIONS, runtime } =
   initApiPassthrough({

--- a/apps/web/src/components/gen-ui/pull-request-opened.tsx
+++ b/apps/web/src/components/gen-ui/pull-request-opened.tsx
@@ -3,11 +3,10 @@
 import { useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import {
-  GitPullRequest,
+  FileDiff,
   Loader2,
   ChevronDown,
-  ExternalLink,
-  GitPullRequestDraft,
+  FileClock,
   Clock,
   Check,
 } from "lucide-react";
@@ -19,7 +18,6 @@ type PullRequestOpenedProps = {
   status: "loading" | "generating" | "done";
   title?: string;
   description?: string;
-  url?: string;
   prNumber?: number;
   branch?: string;
   targetBranch?: string;
@@ -30,7 +28,6 @@ export function PullRequestOpened({
   status,
   title,
   description,
-  url,
   prNumber,
   branch,
   targetBranch = "main",
@@ -67,7 +64,7 @@ export function PullRequestOpened({
               variant="secondary"
               className="border-slate-200 bg-slate-100 text-slate-700 dark:border-slate-700 dark:bg-slate-800/50 dark:text-slate-300"
             >
-              <GitPullRequestDraft className="h-3 w-3" />
+              <FileClock className="h-3 w-3" />
               Draft
             </Badge>
           );
@@ -124,9 +121,9 @@ export function PullRequestOpened({
       >
         <div className="flex h-8 w-8 items-center justify-center rounded-full bg-gray-500 shadow-md dark:bg-gray-600">
           {isDraft ? (
-            <GitPullRequestDraft className="h-4 w-4 text-white" />
+            <FileClock className="h-4 w-4 text-white" />
           ) : (
-            <GitPullRequest className="h-4 w-4 text-white" />
+            <FileDiff className="h-4 w-4 text-white" />
           )}
         </div>
 
@@ -143,23 +140,6 @@ export function PullRequestOpened({
         </div>
 
         <div className="flex items-center gap-2">
-          {url && status === "done" && (
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-8 px-2"
-              asChild
-            >
-              <a
-                href={url}
-                target="_blank"
-                rel="noopener noreferrer"
-                title="Open pull request"
-              >
-                <ExternalLink className="h-4 w-4" />
-              </a>
-            </Button>
-          )}
           {shouldShowToggle() && (
             <Button
               variant="ghost"

--- a/apps/web/src/components/thread/messages/ai.tsx
+++ b/apps/web/src/components/thread/messages/ai.tsx
@@ -623,8 +623,8 @@ export function AssistantMessage({
       : "";
 
     // Extract PR URL from the tool message content
-    // Format: "Created pull request: https://github.com/owner/repo/pull/123"
-    // or "Marked pull request as ready for review: https://github.com/owner/repo/pull/123"
+    // Format: "Created pull request: https://example.com/owner/repo/pull/123"
+    // or "Marked pull request as ready for review: https://example.com/owner/repo/pull/123"
     let prUrl: string | undefined = undefined;
     if (content) {
       if (content.includes("pull request: ")) {

--- a/apps/web/src/components/v2/thread-card.tsx
+++ b/apps/web/src/components/v2/thread-card.tsx
@@ -127,14 +127,6 @@ export function ThreadCard({
               <span className="text-muted-foreground truncate text-xs">
                 {thread.repository}
               </span>
-              {thread.issueId && (
-                <>
-                  <span className="text-muted-foreground text-xs">•</span>
-                  <span className="text-muted-foreground truncate text-xs">
-                    #{thread.issueId}
-                  </span>
-                </>
-              )}
             </div>
           </div>
           <Badge

--- a/apps/web/src/components/v2/thread-view.tsx
+++ b/apps/web/src/components/v2/thread-view.tsx
@@ -379,14 +379,6 @@ export function ThreadView({
                 <span className="text-muted-foreground truncate text-xs">
                   {displayThread.repository}
                 </span>
-                {displayThread.issueId && (
-                  <>
-                    <span className="text-muted-foreground text-xs">•</span>
-                    <span className="text-muted-foreground truncate text-xs">
-                      #{displayThread.issueId}
-                    </span>
-                  </>
-                )}
               </>
             )}
           </div>

--- a/apps/web/src/components/v2/types.ts
+++ b/apps/web/src/components/v2/types.ts
@@ -13,7 +13,6 @@ export interface ThreadMetadata {
   taskCount: number;
   repository: string;
   branch: string;
-  issueId?: number;
   taskPlan?: TaskPlan;
   status: ThreadUIStatus;
   pullRequest?: {

--- a/apps/web/src/hooks/useThreadMetadata.ts
+++ b/apps/web/src/hooks/useThreadMetadata.ts
@@ -34,7 +34,6 @@ export function useThreadMetadata(thread: Thread<ManagerGraphState>): {
         ? `${values.targetRepository.owner}/${values.targetRepository.repo}`
         : "",
       branch: values?.targetRepository?.branch || "main",
-      issueId: values?.githubIssueId,
       taskPlan: realTimeTaskPlan,
       status,
     };

--- a/apps/web/src/lib/thread-utils.ts
+++ b/apps/web/src/lib/thread-utils.ts
@@ -29,7 +29,6 @@ export function threadsToMetadata(
         ? `${values.targetRepository.owner}/${values.targetRepository.repo}`
         : "",
       branch: values?.targetRepository?.branch || "main",
-      issueId: values?.githubIssueId,
       taskPlan: values?.taskPlan,
       status: "idle" as const, // Default status - consumers can override with real status
     };


### PR DESCRIPTION
## Summary
- replace GitHub pull request icons and remove external PR link
- drop GitHub issue id handling from thread metadata and UI
- scrub remaining GitHub references in comments

## Testing
- `yarn lint:fix --filter=@openswe/web`
- `yarn format --filter=@openswe/web`
- `yarn test --filter=@openswe/web`


------
https://chatgpt.com/codex/tasks/task_e_68bf88a4644c832792a91511f5642a5b