### PR TITLE
feat(web): support default user in local mode

### DIFF
--- a/apps/web/src/app/api/auth/user/route.ts
+++ b/apps/web/src/app/api/auth/user/route.ts
@@ -1,10 +1,21 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getSession } from "@/lib/auth";
+import { getSession, type SessionUser } from "@/lib/auth";
+import { isLocalModeFromEnv } from "@openswe/shared/open-swe/local-mode";
 
 export async function GET(request: NextRequest) {
   try {
     const session = getSession(request);
     if (!session) {
+      if (isLocalModeFromEnv()) {
+        const defaultUser: SessionUser = {
+          login: "local-user",
+          avatar_url: "",
+          html_url: "",
+          name: null,
+          email: null,
+        };
+        return NextResponse.json({ user: defaultUser });
+      }
       return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
     }
     return NextResponse.json({ user: session.user });

--- a/apps/web/src/components/v2/terminal-input.tsx
+++ b/apps/web/src/components/v2/terminal-input.tsx
@@ -20,7 +20,7 @@ import {
 import { ManagerGraphUpdate } from "@openswe/shared/open-swe/manager/types";
 import { useDraftStorage } from "@/hooks/useDraftStorage";
 import { hasApiKeySet } from "@/lib/api-keys";
-import { useUser } from "@/hooks/useUser";
+import { useUser, DEFAULT_USER } from "@/hooks/useUser";
 import { isAllowedUser } from "@openswe/shared/allowed-users";
 
 interface TerminalInputProps {
@@ -80,6 +80,7 @@ export function TerminalInput({
   const [selectedRepository] = useQueryState("repo");
   const [loading, setLoading] = useState(false);
   const { user, isLoading: isUserLoading } = useUser();
+  const isLocalMode = process.env.NEXT_PUBLIC_OPEN_SWE_LOCAL_MODE === "true";
 
   const stream = useStream<GraphState>({
     apiUrl,
@@ -97,7 +98,9 @@ export function TerminalInput({
       return;
     }
 
-    if (!user) {
+    const currentUser = user ?? (isLocalMode ? DEFAULT_USER : null);
+
+    if (!currentUser && !isLocalMode) {
       toast.error("User not found. Please sign in first", {
         richColors: true,
         closeButton: true,
@@ -107,7 +110,11 @@ export function TerminalInput({
 
     const defaultConfig = getConfig(DEFAULT_CONFIG_KEY);
 
-    if (!isAllowedUser(user.login) && !hasApiKeySet(defaultConfig)) {
+    if (
+      currentUser &&
+      !isAllowedUser(currentUser.login) &&
+      !hasApiKeySet(defaultConfig)
+    ) {
       toast.error(
         MISSING_API_KEYS_TOAST_CONTENT,
         MISSING_API_KEYS_TOAST_OPTIONS,

--- a/apps/web/src/hooks/useUser.ts
+++ b/apps/web/src/hooks/useUser.ts
@@ -2,6 +2,14 @@ import { useEffect } from "react";
 import useSWR from "swr";
 import { useUserStore, UserData } from "@/stores/user-store";
 
+export const DEFAULT_USER: UserData = {
+  login: "local-user",
+  avatar_url: "",
+  html_url: "",
+  name: null,
+  email: null,
+};
+
 interface UserResponse {
   user: UserData;
 }
@@ -14,12 +22,22 @@ interface UseUserResult {
 }
 
 async function fetchUser(): Promise<UserData> {
-  const response = await fetch("/api/auth/user");
-  if (!response.ok) {
+  try {
+    const response = await fetch("/api/auth/user");
+    if (!response.ok) {
+      if (process.env.NEXT_PUBLIC_OPEN_SWE_LOCAL_MODE === "true") {
+        return DEFAULT_USER;
+      }
+      throw new Error("Failed to fetch user data");
+    }
+    const data: UserResponse = await response.json();
+    return data.user;
+  } catch {
+    if (process.env.NEXT_PUBLIC_OPEN_SWE_LOCAL_MODE === "true") {
+      return DEFAULT_USER;
+    }
     throw new Error("Failed to fetch user data");
   }
-  const data: UserResponse = await response.json();
-  return data.user;
 }
 
 export function useUser(): UseUserResult {


### PR DESCRIPTION
## Summary
- return a local fallback user from `/api/auth/user` when running in local mode without a session
- treat this fallback as an authenticated user within `useUser`
- skip "sign in" warnings in TerminalInput when local mode is enabled

## Testing
- `yarn lint:fix`
- `yarn format`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68c039af76588327991559bc67b968ea