### PR TITLE
feat: send local mode header with terminal stream

### DIFF
--- a/apps/web/src/components/v2/terminal-input.tsx
+++ b/apps/web/src/components/v2/terminal-input.tsx
@@ -87,6 +87,7 @@ export function TerminalInput({
     assistantId,
     reconnectOnMount: true,
     fetchStateHistory: false,
+    defaultHeaders: { "x-local-mode": "true" },
   });
 
   const handleSend = async () => {


### PR DESCRIPTION
## Summary
- add `x-local-mode` default header to terminal stream

## Testing
- `yarn format`
- `yarn lint:fix`
- `yarn build`
- `NEXT_PUBLIC_OPEN_SWE_LOCAL_MODE=true yarn dev`

------
https://chatgpt.com/codex/tasks/task_e_68c0567a2d5483279ff7677db1e8d5e1