### PR TITLE
feat(web): add local mode headers

### DIFF
--- a/apps/web/src/providers/client.ts
+++ b/apps/web/src/providers/client.ts
@@ -1,7 +1,14 @@
 import { Client } from "@langchain/langgraph-sdk";
+import { LOCAL_MODE_HEADER } from "@openswe/shared/constants";
 
 export function createClient(apiUrl: string) {
+  const defaultHeaders =
+    process.env.NEXT_PUBLIC_OPEN_SWE_LOCAL_MODE === "true"
+      ? { [LOCAL_MODE_HEADER]: "true" }
+      : undefined;
+
   return new Client({
     apiUrl,
+    defaultHeaders,
   });
 }


### PR DESCRIPTION
## Summary
- include `x-local-mode` header in LangGraph client when local mode env is enabled

## Testing
- `yarn format --filter=@openswe/web`
- `yarn lint:fix --filter=@openswe/web`
- `yarn test --filter=@openswe/web`


------
https://chatgpt.com/codex/tasks/task_e_68c060150bd883278e410a03ef925ce1