### PR TITLE
Add local mode headers to chat stream

### DIFF
--- a/apps/web/src/app/(v2)/chat/[thread_id]/page.tsx
+++ b/apps/web/src/app/(v2)/chat/[thread_id]/page.tsx
@@ -6,7 +6,7 @@ import { ThreadErrorCard } from "@/components/v2/thread-error-card";
 import { useThreadMetadata } from "@/hooks/useThreadMetadata";
 import { useThreadsSWR } from "@/hooks/useThreadsSWR";
 import { useStream } from "@langchain/langgraph-sdk/react";
-import { MANAGER_GRAPH_ID } from "@openswe/shared/constants";
+import { MANAGER_GRAPH_ID, LOCAL_MODE_HEADER } from "@openswe/shared/constants";
 import { ManagerGraphState } from "@openswe/shared/open-swe/manager/types";
 import { useRouter } from "next/navigation";
 import * as React from "react";
@@ -52,6 +52,7 @@ export default function ThreadPage({
     threadId: thread_id,
     reconnectOnMount: true,
     fetchStateHistory: false,
+    defaultHeaders: { [LOCAL_MODE_HEADER]: "true" },
   });
 
   const { threads, isLoading: threadsLoading } = useThreadsSWR({


### PR DESCRIPTION
## Summary
- forward local mode header when streaming manager chat threads

## Testing
- `yarn lint:fix --filter=@openswe/web`
- `yarn format --filter=@openswe/web`
- `yarn test --filter=@openswe/web`


------
https://chatgpt.com/codex/tasks/task_e_68c067583e4c83278cabc12ba0d3e5d4