### PR TITLE
feat(web): include local mode header in thread streams

### DIFF
--- a/apps/web/src/components/v2/thread-view.tsx
+++ b/apps/web/src/components/v2/thread-view.tsx
@@ -26,6 +26,7 @@ import {
   DO_NOT_RENDER_ID_PREFIX,
   PROGRAMMER_GRAPH_ID,
   PLANNER_GRAPH_ID,
+  LOCAL_MODE_HEADER,
 } from "@openswe/shared/constants";
 import { useThreadStatus } from "@/hooks/useThreadStatus";
 import { cn } from "@/lib/utils";
@@ -185,6 +186,7 @@ export function ThreadView({
       }
     },
     fetchStateHistory: false,
+    defaultHeaders: { [LOCAL_MODE_HEADER]: "true" },
   });
 
   const joinedPlannerRunId = useRef<string | undefined>(undefined);
@@ -211,6 +213,7 @@ export function ThreadView({
       }
     },
     fetchStateHistory: false,
+    defaultHeaders: { [LOCAL_MODE_HEADER]: "true" },
   });
 
   const joinedProgrammerRunId = useRef<string | undefined>(undefined);


### PR DESCRIPTION
## Summary
- add LOCAL_MODE_HEADER default header to planner and programmer useStream calls
- import LOCAL_MODE_HEADER constant in thread view

## Testing
- `yarn lint:fix --filter=@openswe/web`
- `yarn format --filter=@openswe/web`
- `yarn test --filter=@openswe/web`


------
https://chatgpt.com/codex/tasks/task_e_68c067626444832791107cd20ab0991b