### PR TITLE
Specify Azure OpenAI model provider

### DIFF
--- a/apps/open-swe/src/utils/llms/model-manager.ts
+++ b/apps/open-swe/src/utils/llms/model-manager.ts
@@ -198,6 +198,7 @@ export class ModelManager {
 
       return await initChatModel(process.env.AZURE_OPENAI_DEPLOYMENT!, {
         client,
+        modelProvider: "azure-openai",
         maxTokens: finalMaxTokens,
         temperature,
       });


### PR DESCRIPTION
## Summary
- add explicit `modelProvider: "azure-openai"` when initializing Azure OpenAI models
- ensure other `initChatModel` calls already include an explicit provider

## Testing
- `yarn lint:fix`
- `yarn format`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68c095583de4832782fa9bed047be50e