### PR TITLE
Use underscore for Azure model provider

### DIFF
--- a/apps/open-swe/src/utils/llms/model-manager.ts
+++ b/apps/open-swe/src/utils/llms/model-manager.ts
@@ -198,7 +198,7 @@ export class ModelManager {
 
       return await initChatModel(process.env.AZURE_OPENAI_DEPLOYMENT!, {
         client,
-        modelProvider: "azure-openai",
+        modelProvider: "azure_openai",
         maxTokens: finalMaxTokens,
         temperature,
       });


### PR DESCRIPTION
## Summary
- normalize Azure provider string when initializing chat model
- confirm no other Azure modelProvider assignments require updates

## Testing
- `yarn lint:fix`
- `yarn format`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68c09c7c45248327935b27482aac2067