### PR TITLE
feat: validate Azure deployment names

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Open SWE can be used in multiple ways:
 
 Open SWE runs locally without any external repository-hosting dependencies or authentication. Configure your environment variables (such as `AZURE_OPENAI_API_KEY`) and start the agent to connect to Azure-hosted GPT‑5 models or other supported LLMs.
 
+When specifying models, Azure OpenAI expects deployment names rather than raw model IDs. Use the `azure-openai:<deployment-name>` syntax, for example `azure-openai:my-gpt5-deployment`. If your deployment name matches a base model ID (e.g., `azure-openai:gpt-4o`), ensure that a deployment with that name exists.
+
 # Documentation
 
 To get started using Open SWE locally, see the [documentation here](https://docs.langchain.com/labs/swe/).

--- a/apps/open-swe/src/utils/llms/model-manager.ts
+++ b/apps/open-swe/src/utils/llms/model-manager.ts
@@ -185,6 +185,17 @@ export class ModelManager {
     const apiKey = this.getUserApiKey(graphConfig, provider);
 
     if (provider === "azure-openai") {
+      if (!modelName) {
+        throw new Error(
+          "Azure OpenAI requires a deployment name. Set AZURE_OPENAI_DEPLOYMENT or configure a model name in GraphConfig.",
+        );
+      }
+      if (/^(gpt|o\d)/i.test(modelName)) {
+        logger.warn(
+          `Azure OpenAI expects a deployment name; using "${modelName}" as deployment. Ensure a deployment with this name exists.`,
+        );
+      }
+
       const client = new AzureOpenAI({
         apiKey: apiKey ?? process.env.AZURE_OPENAI_API_KEY,
         apiVersion: process.env.AZURE_OPENAI_API_VERSION,
@@ -196,7 +207,7 @@ export class ModelManager {
         modelName,
       });
 
-      return await initChatModel(process.env.AZURE_OPENAI_DEPLOYMENT!, {
+      return await initChatModel(modelName, {
         client,
         modelProvider: "azure_openai",
         maxTokens: finalMaxTokens,


### PR DESCRIPTION
## Summary
- ensure Azure OpenAI deployments can reuse base model names by warning instead of failing
- document that Azure deployment names may match base model IDs

## Testing
- `yarn lint:fix`
- `yarn format`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68c0a572ff9c83278ddfc12d134f5ae7