### PR TITLE
Forward Azure API version to AzureChatOpenAI

### DIFF
--- a/apps/open-swe/src/utils/llms/model-manager.ts
+++ b/apps/open-swe/src/utils/llms/model-manager.ts
@@ -193,7 +193,6 @@ export class ModelManager {
       if (/^(gpt|o\d)/i.test(modelName)) {
         logger.warn(
           `Azure OpenAI expects a deployment name; using "${modelName}" as deployment. Ensure a deployment with this name exists.`,
-
         );
       }
       const apiVersion = process.env.AZURE_OPENAI_API_VERSION;
@@ -205,7 +204,6 @@ export class ModelManager {
         modelName,
         provider,
       });
-
 
       const client = new AzureOpenAI({
         apiKey: apiKey ?? process.env.AZURE_OPENAI_API_KEY,
@@ -226,6 +224,7 @@ export class ModelManager {
         modelProvider: "azure_openai",
         maxTokens: finalMaxTokens,
         temperature,
+        openAIApiVersion: apiVersion,
       });
     }
 


### PR DESCRIPTION
## Summary
- forward Azure API version when initializing Azure OpenAI chat models

## Testing
- `yarn lint:fix`
- `yarn format`
- `yarn test`
- `cd apps/open-swe && node --experimental-vm-modules ../../node_modules/jest/bin/jest.js --config jest.config.js --testPathPattern=int.test.ts`
- verified local AzureOpenAI request with `OPENAI_API_VERSION` unset


------
https://chatgpt.com/codex/tasks/task_e_68c0c2c75de08327b7610b04799fea2c