### PR TITLE
feat: persist scratchpad notes

### DIFF
--- a/apps/open-swe/package.json
+++ b/apps/open-swe/package.json
@@ -29,6 +29,7 @@
     "@langchain/core": "^0.3.65",
     "@langchain/google-genai": "^0.2.9",
     "@langchain/langgraph": "^0.3.8",
+    "@langchain/langgraph-checkpoint": "^0.1.0",
     "@langchain/langgraph-sdk": "^0.0.95",
     "@langchain/mcp-adapters": "^0.5.2",
     "@langchain/openai": "^0.5.10",

--- a/apps/open-swe/src/tools/__tests__/scratchpad.test.ts
+++ b/apps/open-swe/src/tools/__tests__/scratchpad.test.ts
@@ -1,0 +1,30 @@
+import { beforeEach, describe, expect, test, jest } from "@jest/globals";
+
+const getMock = jest.fn();
+const putMock = jest.fn();
+
+await jest.unstable_mockModule("@langchain/langgraph", () => ({
+  getStore: () => ({ get: getMock, put: putMock }),
+}));
+
+const { writeScratchpad } = await import("../scratchpad.js");
+
+beforeEach(() => {
+  getMock.mockReset().mockResolvedValue(null);
+  putMock.mockReset();
+});
+
+describe("scratchpad tool saved state", () => {
+  test("persists notes between invocations", async () => {
+    await writeScratchpad({ scratchpad: ["First"] });
+    expect(putMock).toHaveBeenLastCalledWith(["scratchpad"], "notes", {
+      notes: ["First"],
+    });
+
+    getMock.mockResolvedValueOnce({ value: { notes: ["First"] } });
+    await writeScratchpad({ scratchpad: ["Second"] });
+    expect(putMock).toHaveBeenLastCalledWith(["scratchpad"], "notes", {
+      notes: ["First", "Second"],
+    });
+  });
+});

--- a/apps/open-swe/src/tools/scratchpad.ts
+++ b/apps/open-swe/src/tools/scratchpad.ts
@@ -1,17 +1,34 @@
 import { tool } from "@langchain/core/tools";
+import { getStore } from "@langchain/langgraph";
 import { createScratchpadFields } from "@openswe/shared/open-swe/tools";
+
+export async function writeScratchpad(input: {
+  scratchpad: string[];
+}): Promise<{ result: string; status: "success" | "error" }> {
+  const store = getStore();
+  if (!store) {
+    return {
+      result: "Unable to access scratchpad store.",
+      status: "error",
+    };
+  }
+
+  const existing = await store.get(["scratchpad"], "notes");
+  const previousNotes = (existing?.value?.notes as string[] | undefined) ?? [];
+
+  await store.put(["scratchpad"], "notes", {
+    notes: [...previousNotes, ...input.scratchpad],
+  });
+
+  return {
+    result: "Successfully wrote to scratchpad. Thank you!",
+    status: "success",
+  };
+}
 
 export function createScratchpadTool(whenMessage: string) {
   const scratchpadTool = tool(
-    async (
-      _input,
-    ): Promise<{ result: string; status: "success" | "error" }> => {
-      // TODO: This should write to saved state once that feature is released in LangGraph.
-      return {
-        result: "Successfully wrote to scratchpad. Thank you!",
-        status: "success",
-      };
-    },
+    writeScratchpad,
     createScratchpadFields(whenMessage),
   );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3906,6 +3906,7 @@ __metadata:
     "@langchain/core": ^0.3.65
     "@langchain/google-genai": ^0.2.9
     "@langchain/langgraph": ^0.3.8
+    "@langchain/langgraph-checkpoint": ^0.1.0
     "@langchain/langgraph-cli": ^0.0.47
     "@langchain/langgraph-sdk": ^0.0.95
     "@langchain/mcp-adapters": ^0.5.2


### PR DESCRIPTION
## Summary
- write scratchpad notes to LangGraph saved state
- add regression test for scratchpad persistence
- include langgraph checkpoint dependency

## Testing
- `yarn lint:fix`
- `yarn format`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68c0e01c2ef883278f36db77fdab46e3