### PR TITLE
fix: resolve build errors

### DIFF
--- a/apps/open-swe/src/tools/__tests__/scratchpad.test.ts
+++ b/apps/open-swe/src/tools/__tests__/scratchpad.test.ts
@@ -1,7 +1,16 @@
 import { beforeEach, describe, expect, test, jest } from "@jest/globals";
 
-const getMock = jest.fn();
-const putMock = jest.fn();
+const getMock =
+  jest.fn<
+    (
+      path: string[],
+      key: string,
+    ) => Promise<{ value: { notes: string[] } } | null>
+  >();
+const putMock =
+  jest.fn<
+    (path: string[], key: string, value: { notes: string[] }) => Promise<void>
+  >();
 
 await jest.unstable_mockModule("@langchain/langgraph", () => ({
   getStore: () => ({ get: getMock, put: putMock }),

--- a/apps/web/src/components/api-key-banner.tsx
+++ b/apps/web/src/components/api-key-banner.tsx
@@ -6,7 +6,7 @@ import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { useUser } from "@/hooks/useUser";
 import { useConfigStore, DEFAULT_CONFIG_KEY } from "@/hooks/useConfigStore";
-import { isAllowedUser } from "@openswe/shared/allowed-users";
+import { isAllowedUser } from "@/lib/is-allowed-user";
 import Link from "next/link";
 import { hasApiKeySet } from "@/lib/api-keys";
 

--- a/apps/web/src/components/thread/messages/ai.tsx
+++ b/apps/web/src/components/thread/messages/ai.tsx
@@ -53,7 +53,7 @@ import { z } from "zod";
 import { isAIMessageSDK, isToolMessageSDK } from "@/lib/langchain-messages";
 import { useStream } from "@langchain/langgraph-sdk/react";
 import { ConversationHistorySummary } from "@/components/gen-ui/conversation-summary";
-import { getMessageContentString } from "@openswe/shared/messages";
+import { getMessageContentString } from "@/lib/get-message-content-string";
 import { HumanResponse } from "@langchain/langgraph/prebuilt";
 import { OPEN_SWE_STREAM_MODE } from "@openswe/shared/constants";
 import { CustomNodeEvent } from "@openswe/shared/open-swe/custom-node-events";

--- a/apps/web/src/components/v2/manager-chat.tsx
+++ b/apps/web/src/components/v2/manager-chat.tsx
@@ -1,6 +1,6 @@
 import { ScrollToBottom, StickyToBottomContent } from "@/utils/scroll-utils";
 import { Message } from "@langchain/langgraph-sdk";
-import { getMessageContentString } from "@openswe/shared/messages";
+import { getMessageContentString } from "@/lib/get-message-content-string";
 import { useState } from "react";
 import { StickToBottom } from "use-stick-to-bottom";
 import { TooltipIconButton } from "../ui/tooltip-icon-button";

--- a/apps/web/src/components/v2/terminal-input.tsx
+++ b/apps/web/src/components/v2/terminal-input.tsx
@@ -21,7 +21,7 @@ import { ManagerGraphUpdate } from "@openswe/shared/open-swe/manager/types";
 import { useDraftStorage } from "@/hooks/useDraftStorage";
 import { hasApiKeySet } from "@/lib/api-keys";
 import { useUser, DEFAULT_USER } from "@/hooks/useUser";
-import { isAllowedUser } from "@openswe/shared/allowed-users";
+import { isAllowedUser } from "@/lib/is-allowed-user";
 
 interface TerminalInputProps {
   placeholder?: string;

--- a/apps/web/src/components/v2/thread-view.tsx
+++ b/apps/web/src/components/v2/thread-view.tsx
@@ -48,7 +48,7 @@ import {
 import { StickToBottom } from "use-stick-to-bottom";
 import { TokenUsage } from "./token-usage";
 import { HumanMessage as HumanMessageSDK } from "@langchain/langgraph-sdk";
-import { getMessageContentString } from "@openswe/shared/messages";
+import { getMessageContentString } from "@/lib/get-message-content-string";
 
 interface ThreadViewProps {
   stream: ReturnType<typeof useStream<ManagerGraphState>>;

--- a/apps/web/src/hooks/useThreadsSWR.ts
+++ b/apps/web/src/hooks/useThreadsSWR.ts
@@ -142,7 +142,6 @@ export function useThreadsSWR<
         });
       }
       throw error;
-
     } finally {
       if (timeoutId) {
         clearTimeout(timeoutId);

--- a/apps/web/src/lib/get-message-content-string.ts
+++ b/apps/web/src/lib/get-message-content-string.ts
@@ -1,0 +1,15 @@
+import { MessageContent } from "@langchain/core/messages";
+
+export function getMessageContentString(content: MessageContent): string {
+  try {
+    if (typeof content === "string") return content;
+
+    return content
+      .filter((c): c is { type: "text"; text: string } => c.type === "text")
+      .map((c) => c.text)
+      .join(" ");
+  } catch (error) {
+    console.error("Failed to get message content string", error);
+    return "";
+  }
+}

--- a/apps/web/src/lib/is-allowed-user.ts
+++ b/apps/web/src/lib/is-allowed-user.ts
@@ -1,0 +1,28 @@
+export function isAllowedUser(username: string): boolean {
+  const nodeEnv = process.env.NODE_ENV;
+  if (nodeEnv !== "production") {
+    return true;
+  }
+
+  const restrictToLangChainAuth =
+    process.env.RESTRICT_TO_LANGCHAIN_AUTH === "true" ||
+    process.env.NEXT_PUBLIC_RESTRICT_TO_LANGCHAIN_AUTH === "true";
+  if (!restrictToLangChainAuth) {
+    return true;
+  }
+
+  let allowedUsers: string[] = [];
+  try {
+    allowedUsers = process.env.NEXT_PUBLIC_ALLOWED_USERS_LIST
+      ? JSON.parse(process.env.NEXT_PUBLIC_ALLOWED_USERS_LIST)
+      : [];
+    if (!allowedUsers.length) {
+      return false;
+    }
+  } catch (error) {
+    console.error("Failed to parse allowed users list", error);
+    return false;
+  }
+
+  return allowedUsers.some((u) => u === username);
+}

--- a/apps/web/src/lib/thread.ts
+++ b/apps/web/src/lib/thread.ts
@@ -1,5 +1,5 @@
 import { Thread } from "@langchain/langgraph-sdk";
-import { getMessageContentString } from "@openswe/shared/messages";
+import { getMessageContentString } from "./get-message-content-string";
 import { GraphState, TaskPlan } from "@openswe/shared/open-swe/types";
 import { getActivePlanItems } from "@openswe/shared/open-swe/tasks";
 


### PR DESCRIPTION
## Summary
- add explicit types for mock functions in scratchpad tests
- avoid node-only deps in web by localizing message parsing and allowed-user logic

## Testing
- `yarn lint --filter=@openswe/web`
- `yarn lint`
- `yarn test --filter=@openswe/shared --filter=@openswe/agent`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68c0dbc42c808327a7f74aaac76f8360