### PR TITLE
feat: add OpenAI API version fallback for Azure

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,15 @@ Open SWE can be used in multiple ways:
 
 Open SWE runs locally without any external repository-hosting dependencies or authentication. Configure your environment variables (such as `AZURE_OPENAI_API_KEY`) and start the agent to connect to Azure-hosted GPT‑5 models or other supported LLMs.
 
+### Environment Variables
+
+The agent recognizes the following environment variables for Azure OpenAI compatibility:
+
+- `AZURE_OPENAI_API_KEY` – Azure OpenAI API key
+- `AZURE_OPENAI_ENDPOINT` – Azure OpenAI endpoint URL
+- `AZURE_OPENAI_API_VERSION` – API version used when set
+- `OPENAI_API_VERSION` – fallback API version if `AZURE_OPENAI_API_VERSION` is unset
+
 When specifying models, Azure OpenAI expects deployment names rather than raw model IDs. Use the `azure-openai:<deployment-name>` syntax, for example `azure-openai:my-gpt5-deployment`. If your deployment name matches a base model ID (e.g., `azure-openai:gpt-4o`), ensure that a deployment with that name exists.
 
 # Documentation

--- a/apps/open-swe/src/utils/llms/model-manager.ts
+++ b/apps/open-swe/src/utils/llms/model-manager.ts
@@ -195,11 +195,19 @@ export class ModelManager {
           `Azure OpenAI expects a deployment name; using "${modelName}" as deployment. Ensure a deployment with this name exists.`,
         );
       }
-      const apiVersion = process.env.AZURE_OPENAI_API_VERSION;
+      const apiVersion =
+        process.env.AZURE_OPENAI_API_VERSION ?? process.env.OPENAI_API_VERSION;
+      const apiVersionEnvVar =
+        process.env.AZURE_OPENAI_API_VERSION !== undefined
+          ? "AZURE_OPENAI_API_VERSION"
+          : process.env.OPENAI_API_VERSION !== undefined
+            ? "OPENAI_API_VERSION"
+            : undefined;
       const endpoint = process.env.AZURE_OPENAI_ENDPOINT;
 
       logger.info("Creating Azure OpenAI client", {
         apiVersion,
+        apiVersionEnvVar,
         endpoint,
         modelName,
         provider,
@@ -213,6 +221,7 @@ export class ModelManager {
 
       logger.info("Initializing Azure OpenAI model", {
         apiVersion,
+        apiVersionEnvVar,
         endpoint,
         modelName,
         maxTokens: finalMaxTokens,


### PR DESCRIPTION
## Summary
- fallback to `OPENAI_API_VERSION` when `AZURE_OPENAI_API_VERSION` is unset
- log which API version environment variable is used
- document API version variables in README

## Testing
- `yarn lint:fix`
- `yarn format`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68c0f6a471bc83278326ccce16ee7146