### PR TITLE
fix: azure api version fallback and gpt-5 max tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Open SWE can be used in multiple ways:
 
 Open SWE runs locally without any external repository-hosting dependencies or authentication. Configure your environment variables (such as `AZURE_OPENAI_API_KEY`) and start the agent to connect to Azure-hosted GPT‑5 models or other supported LLMs.
 
+For the Azure OpenAI API version, set `AZURE_OPENAI_API_VERSION` (preferred) or `OPENAI_API_VERSION`. The agent will use `AZURE_OPENAI_API_VERSION` when available and fall back to `OPENAI_API_VERSION` otherwise.
+
 When specifying models, Azure OpenAI expects deployment names rather than raw model IDs. Use the `azure-openai:<deployment-name>` syntax, for example `azure-openai:my-gpt5-deployment`. If your deployment name matches a base model ID (e.g., `azure-openai:gpt-4o`), ensure that a deployment with that name exists.
 
 # Documentation

--- a/apps/open-swe/src/utils/llms/model-manager.ts
+++ b/apps/open-swe/src/utils/llms/model-manager.ts
@@ -29,6 +29,7 @@ interface ModelLoadConfig {
   modelName: string;
   temperature?: number;
   maxTokens?: number;
+  max_completion_tokens?: number;
   thinkingModel?: boolean;
   thinkingBudgetTokens?: number;
 }
@@ -169,6 +170,7 @@ export class ModelManager {
       modelName,
       temperature,
       maxTokens,
+      max_completion_tokens,
       thinkingModel,
       thinkingBudgetTokens,
     } = config;
@@ -176,8 +178,7 @@ export class ModelManager {
     const thinkingMaxTokens = thinkingBudgetTokens
       ? thinkingBudgetTokens * 4
       : undefined;
-
-    let finalMaxTokens = maxTokens ?? 10_000;
+    let finalMaxTokens = max_completion_tokens ?? maxTokens ?? 10_000;
     if (modelName.includes("claude-3-5-haiku")) {
       finalMaxTokens = finalMaxTokens > 8_192 ? 8_192 : finalMaxTokens;
     }
@@ -195,11 +196,16 @@ export class ModelManager {
           `Azure OpenAI expects a deployment name; using "${modelName}" as deployment. Ensure a deployment with this name exists.`,
         );
       }
-      const apiVersion = process.env.AZURE_OPENAI_API_VERSION;
+      const apiVersion =
+        process.env.AZURE_OPENAI_API_VERSION ?? process.env.OPENAI_API_VERSION;
+      const apiVersionEnvVar = process.env.AZURE_OPENAI_API_VERSION
+        ? "AZURE_OPENAI_API_VERSION"
+        : "OPENAI_API_VERSION";
       const endpoint = process.env.AZURE_OPENAI_ENDPOINT;
 
       logger.info("Creating Azure OpenAI client", {
         apiVersion,
+        apiVersionEnvVar,
         endpoint,
         modelName,
         provider,
@@ -211,19 +217,24 @@ export class ModelManager {
         endpoint,
       });
 
+      const useMaxCompletion = modelName.includes("gpt-5");
+
       logger.info("Initializing Azure OpenAI model", {
         apiVersion,
+        apiVersionEnvVar,
         endpoint,
         modelName,
-        maxTokens: finalMaxTokens,
-        temperature,
+        ...(useMaxCompletion
+          ? { max_completion_tokens: finalMaxTokens, temperature: 1 }
+          : { maxTokens: finalMaxTokens, temperature }),
       });
 
       return await initChatModel(modelName, {
         client,
         modelProvider: "azure_openai",
-        maxTokens: finalMaxTokens,
-        temperature,
+        ...(useMaxCompletion
+          ? { max_completion_tokens: finalMaxTokens, temperature: 1 }
+          : { maxTokens: finalMaxTokens, temperature }),
         openAIApiVersion: apiVersion,
       });
     }


### PR DESCRIPTION
## Summary
- support OPENAI_API_VERSION as fallback when AZURE_OPENAI_API_VERSION is unset
- use `max_completion_tokens` for Azure GPT-5 deployments
- document accepted Azure API version variables

## Testing
- `yarn lint:fix`
- `yarn format`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68c0f48b40b083278fc3bbe5ff4b249b