### PR TITLE
feat: make sandbox path configurable

### DIFF
--- a/apps/open-swe/src/tools/builtin-tools/text-editor.ts
+++ b/apps/open-swe/src/tools/builtin-tools/text-editor.ts
@@ -15,7 +15,7 @@ import {
   isLocalMode,
   getLocalWorkingDirectory,
 } from "@openswe/shared/open-swe/local-mode";
-import { TIMEOUT_SEC } from "@openswe/shared/constants";
+import { TIMEOUT_SEC, SANDBOX_ROOT_DIR } from "@openswe/shared/constants";
 import { getLocalShellExecutor } from "../../utils/shell-executor/index.js";
 
 const logger = createLogger(LogLevel.INFO, "TextEditorTool");
@@ -41,6 +41,8 @@ export function createTextEditorTool(
         const localAbsolutePath = getLocalWorkingDirectory();
         const sandboxAbsolutePath = getRepoAbsolutePath(state.targetRepository);
         const workDir = localMode ? localAbsolutePath : sandboxAbsolutePath;
+        const projectPrefix = `${SANDBOX_ROOT_DIR}/project/`;
+        const localPrefix = `${SANDBOX_ROOT_DIR}/local/`;
         let result: string;
 
         if (localMode) {
@@ -49,12 +51,12 @@ export function createTextEditorTool(
 
           // Convert sandbox path to local path
           let localPath = path;
-          if (path.startsWith("/home/daytona/project/")) {
+          if (path.startsWith(projectPrefix)) {
             // Remove the sandbox prefix to get the relative path
-            localPath = path.replace("/home/daytona/project/", "");
-          } else if (path.startsWith("/home/daytona/local/")) {
+            localPath = path.replace(projectPrefix, "");
+          } else if (path.startsWith(localPrefix)) {
             // Remove the local sandbox prefix to get the relative path
-            localPath = path.replace("/home/daytona/local/", "");
+            localPath = path.replace(localPrefix, "");
           }
           const filePath = join(workDir, localPath);
 

--- a/apps/open-swe/src/tools/builtin-tools/view.ts
+++ b/apps/open-swe/src/tools/builtin-tools/view.ts
@@ -10,7 +10,7 @@ import {
   isLocalMode,
   getLocalWorkingDirectory,
 } from "@openswe/shared/open-swe/local-mode";
-import { TIMEOUT_SEC } from "@openswe/shared/constants";
+import { TIMEOUT_SEC, SANDBOX_ROOT_DIR } from "@openswe/shared/constants";
 import { createShellExecutor } from "../../utils/shell-executor/index.js";
 
 const logger = createLogger(LogLevel.INFO, "ViewTool");
@@ -38,9 +38,10 @@ export function createViewTool(
 
           // Convert sandbox path to local path
           let localPath = path;
-          if (path.startsWith("/home/daytona/project/")) {
+          const projectPrefix = `${SANDBOX_ROOT_DIR}/project/`;
+          if (path.startsWith(projectPrefix)) {
             // Remove the sandbox prefix to get the relative path
-            localPath = path.replace("/home/daytona/project/", "");
+            localPath = path.replace(projectPrefix, "");
           }
           const filePath = join(workDir, localPath);
 

--- a/packages/shared/src/__tests__/git.test.ts
+++ b/packages/shared/src/__tests__/git.test.ts
@@ -1,0 +1,24 @@
+import { jest } from "@jest/globals";
+
+// tests will import getRepoAbsolutePath after setting env variable
+
+describe("getRepoAbsolutePath", () => {
+  const originalSandboxRoot = process.env.SANDBOX_ROOT_DIR;
+
+  afterEach(() => {
+    jest.resetModules();
+    if (originalSandboxRoot === undefined) {
+      delete process.env.SANDBOX_ROOT_DIR;
+    } else {
+      process.env.SANDBOX_ROOT_DIR = originalSandboxRoot;
+    }
+  });
+
+  it("resolves repository path using SANDBOX_ROOT_DIR env", async () => {
+    process.env.SANDBOX_ROOT_DIR = "/tmp/custom-root";
+    jest.resetModules();
+    const { getRepoAbsolutePath } = await import("../git.js");
+    const target = { owner: "foo", repo: "bar" };
+    expect(getRepoAbsolutePath(target)).toBe("/tmp/custom-root/bar");
+  });
+});

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -1,5 +1,5 @@
 export const TIMEOUT_SEC = 60; // 1 minute
-export const SANDBOX_ROOT_DIR = "/home/daytona";
+export const SANDBOX_ROOT_DIR = process.env.SANDBOX_ROOT_DIR ?? "/home/daytona";
 export const DAYTONA_IMAGE_NAME = "daytonaio/langchain-open-swe:0.1.0";
 export const DAYTONA_SNAPSHOT_NAME = "open-swe-vcpu2-mem4-disk5";
 export const PLAN_INTERRUPT_DELIMITER = ":::";

--- a/packages/shared/src/git.ts
+++ b/packages/shared/src/git.ts
@@ -1,3 +1,4 @@
+import { join } from "path";
 import { SANDBOX_ROOT_DIR } from "./constants.js";
 import { TargetRepository, GraphConfig } from "./open-swe/types.js";
 import {
@@ -19,5 +20,5 @@ export function getRepoAbsolutePath(
     throw new Error("No repository name provided");
   }
 
-  return `${SANDBOX_ROOT_DIR}/${repoName}`;
+  return join(SANDBOX_ROOT_DIR, repoName);
 }


### PR DESCRIPTION
## Summary
- allow SANDBOX_ROOT_DIR to be configured via environment
- use SANDBOX_ROOT_DIR when resolving repo paths and local tool prefixes
- add test for SANDBOX_ROOT_DIR override

## Testing
- `yarn format`
- `yarn lint:fix`
- `yarn build`
- `yarn test`
- `yarn test:int` *(fails: Couldn't find a script named "test:int")*


------
https://chatgpt.com/codex/tasks/task_e_68c0fb52e41083279e44d1523f9970db