### PR TITLE
chore: drop daytona references

### DIFF
--- a/apps/docs/faq.mdx
+++ b/apps/docs/faq.mdx
@@ -44,7 +44,7 @@ description: Frequently Asked Questions
 
 
 <Accordion title="What sandbox environment is Open SWE running in?">
-  Open SWE's sandbox environment is powered by [Daytona.io](https://daytona.io).
+  Open SWE's sandbox environment runs in the selected local repository path.
 </Accordion>
 
 <Accordion title="Can I contribute to Open SWE?">

--- a/apps/docs/secrets.mdx
+++ b/apps/docs/secrets.mdx
@@ -52,7 +52,7 @@ You may wonder, why does the sandbox environment even need API keys? We've desig
 </Note>
 
 **Default Behavior (Secure):**
-- API keys are only used for LLM model initialization & setting up Daytona using your own key, if you passed it
+- API keys are only used for LLM model initialization and optional sandbox setup if you supply a key
 - Keys are NOT available as environment variables in sandboxes or accessible to LLMs
 - Each key has `allowedInDev: false` by default
 
@@ -65,7 +65,7 @@ You may wonder, why does the sandbox environment even need API keys? We've desig
 
 ### Container Isolation
 
-Each user session runs in a completely isolated Daytona container with multiple security boundaries. These containers can modify the code in your repo on a new branch and don't exchange information across sessions.
+Each user session runs in a completely isolated container with multiple security boundaries. These containers can modify the code in your repo on a new branch and don't exchange information across sessions.
 
 <Accordion title="Isolation Details">
   **Container Isolation:**

--- a/apps/docs/setup/intro.mdx
+++ b/apps/docs/setup/intro.mdx
@@ -38,7 +38,7 @@ Open SWE is built with modern technologies designed for scalability and develope
   - Manager graph for user interaction orchestration
   - Planner graph for execution plan creation
   - Programmer graph for code change execution
-- **Daytona** - Sandboxed development environments for safe code execution
+- **Local sandbox** - Sandboxed development environments for safe code execution
 
 ### Web Application
 

--- a/apps/open-swe/src/constants.ts
+++ b/apps/open-swe/src/constants.ts
@@ -1,10 +1,20 @@
-import { DAYTONA_SNAPSHOT_NAME } from "@openswe/shared/constants";
 import { CreateSandboxFromSnapshotParams } from "@daytonaio/sdk";
+import { getLocalWorkingDirectory } from "@openswe/shared/open-swe/local-mode";
+import { mkdtempSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const DEFAULT_SANDBOX_PATH =
+  process.env.OPEN_SWE_PROJECT_PATH ||
+  getLocalWorkingDirectory() ||
+  mkdtempSync(path.join(os.tmpdir(), "open-swe-"));
 
 export const DEFAULT_SANDBOX_CREATE_PARAMS: CreateSandboxFromSnapshotParams = {
-  user: "daytona",
-  snapshot: DAYTONA_SNAPSHOT_NAME,
+  user: "open-swe",
   autoDeleteInterval: 15, // delete after 15 minutes
+  envVars: {
+    SANDBOX_ROOT_DIR: DEFAULT_SANDBOX_PATH,
+  },
 };
 
 export const LANGGRAPH_USER_PERMISSIONS = [

--- a/apps/web/src/features/settings-page/api-keys.tsx
+++ b/apps/web/src/features/settings-page/api-keys.tsx
@@ -77,13 +77,6 @@ const API_KEY_DEFINITIONS = {
       ],
     },
   ],
-  // infrastructure: [
-  //   {
-  //     id: "daytonaApiKey",
-  //     name: "Daytona",
-  //     description: "Users not required to set this if using the demo",
-  //   },
-  // ],
 };
 
 const shouldAutofocus = (apiKeyId: string, hasValue: boolean): boolean => {

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -1,7 +1,8 @@
+import { getLocalWorkingDirectory } from "./open-swe/local-mode.js";
+
 export const TIMEOUT_SEC = 60; // 1 minute
-export const SANDBOX_ROOT_DIR = process.env.SANDBOX_ROOT_DIR ?? "/home/daytona";
-export const DAYTONA_IMAGE_NAME = "daytonaio/langchain-open-swe:0.1.0";
-export const DAYTONA_SNAPSHOT_NAME = "open-swe-vcpu2-mem4-disk5";
+export const SANDBOX_ROOT_DIR =
+  process.env.SANDBOX_ROOT_DIR ?? getLocalWorkingDirectory();
 export const PLAN_INTERRUPT_DELIMITER = ":::";
 export const PLAN_INTERRUPT_ACTION_TITLE = "Approve/Edit Plan";
 export const LOCAL_MODE_HEADER = "x-local-mode";

--- a/packages/shared/src/open-swe/local-mode.ts
+++ b/packages/shared/src/open-swe/local-mode.ts
@@ -2,7 +2,7 @@ import { GraphConfig } from "@openswe/shared/open-swe/types";
 
 /**
  * Checks if the current execution context is in local mode
- * (working on local files instead of sandbox/Daytona)
+ * (working on local files instead of a remote sandbox)
  */
 export function isLocalMode(config?: GraphConfig): boolean {
   if (!config) {


### PR DESCRIPTION
## Summary
- replace hardcoded Daytona paths with selected repo path
- remove Daytona mentions from docs and UI
- configure sandbox creation to run inside chosen local repo or a temporary workspace

## Testing
- `yarn lint:fix`
- `yarn format`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68c1732e79d083279ec2b64873b4c721