### PR TITLE
feat: add docker sandbox

### DIFF
--- a/apps/open-swe/langbench/types.ts
+++ b/apps/open-swe/langbench/types.ts
@@ -1,4 +1,4 @@
-import { Sandbox } from "@daytonaio/sdk";
+import type { Sandbox } from "../src/utils/sandbox.js";
 
 export interface PRData {
   url: string;

--- a/apps/open-swe/package.json
+++ b/apps/open-swe/package.json
@@ -41,6 +41,7 @@
     "jsonwebtoken": "^9.0.2",
     "langchain": "^0.3.26",
     "langsmith": "^0.3.29",
+    "dockerode": "^4.0.2",
     "uuid": "^11.0.5",
     "zod": "^3.25.32"
   },

--- a/apps/open-swe/src/constants.ts
+++ b/apps/open-swe/src/constants.ts
@@ -1,4 +1,3 @@
-import { CreateSandboxFromSnapshotParams } from "@daytonaio/sdk";
 import { getLocalWorkingDirectory } from "@openswe/shared/open-swe/local-mode";
 import { mkdtempSync } from "node:fs";
 import os from "node:os";
@@ -9,9 +8,9 @@ const DEFAULT_SANDBOX_PATH =
   getLocalWorkingDirectory() ||
   mkdtempSync(path.join(os.tmpdir(), "open-swe-"));
 
-export const DEFAULT_SANDBOX_CREATE_PARAMS: CreateSandboxFromSnapshotParams = {
+export const DEFAULT_SANDBOX_CREATE_PARAMS = {
   user: "open-swe",
-  autoDeleteInterval: 15, // delete after 15 minutes
+  autoDeleteInterval: 15,
   envVars: {
     SANDBOX_ROOT_DIR: DEFAULT_SANDBOX_PATH,
   },

--- a/apps/open-swe/src/graphs/reviewer/nodes/initialize-state.ts
+++ b/apps/open-swe/src/graphs/reviewer/nodes/initialize-state.ts
@@ -10,7 +10,7 @@ import { AIMessage, ToolMessage } from "@langchain/core/messages";
 import { v4 as uuidv4 } from "uuid";
 import { createReviewStartedToolFields } from "@openswe/shared/open-swe/tools";
 import { getSandboxErrorFields } from "../../../utils/sandbox-error-fields.js";
-import { Sandbox } from "@daytonaio/sdk";
+import type { Sandbox } from "../../../utils/sandbox.js";
 import { createShellExecutor } from "../../../utils/shell-executor/index.js";
 
 const logger = createLogger(LogLevel.INFO, "InitializeStateNode");

--- a/apps/open-swe/src/tools/apply-patch.ts
+++ b/apps/open-swe/src/tools/apply-patch.ts
@@ -7,7 +7,7 @@ import { createLogger, LogLevel } from "../utils/logger.js";
 import { createApplyPatchToolFields } from "@openswe/shared/open-swe/tools";
 import { getRepoAbsolutePath } from "@openswe/shared/git";
 import { getSandboxSessionOrThrow } from "./utils/get-sandbox-id.js";
-import { Sandbox } from "@daytonaio/sdk";
+import type { Sandbox } from "../utils/sandbox.js";
 import {
   isLocalMode,
   getLocalWorkingDirectory,

--- a/apps/open-swe/src/tools/builtin-tools/handlers.ts
+++ b/apps/open-swe/src/tools/builtin-tools/handlers.ts
@@ -1,4 +1,4 @@
-import { Sandbox } from "@daytonaio/sdk";
+import type { Sandbox } from "../../utils/sandbox.js";
 import { readFile, writeFile } from "../../utils/read-write.js";
 import { getSandboxErrorFields } from "../../utils/sandbox-error-fields.js";
 import { GraphConfig } from "@openswe/shared/open-swe/types";

--- a/apps/open-swe/src/tools/utils/get-sandbox-id.ts
+++ b/apps/open-swe/src/tools/utils/get-sandbox-id.ts
@@ -1,16 +1,15 @@
 import { getCurrentTaskInput } from "@langchain/langgraph";
 import { GraphState } from "@openswe/shared/open-swe/types";
 import { createLogger, LogLevel } from "../../utils/logger.js";
-import { daytonaClient } from "../../utils/sandbox.js";
-import { Sandbox } from "@daytonaio/sdk";
+import { getSandbox } from "../../utils/sandbox.js";
+import type { Sandbox } from "../../utils/sandbox.js";
 
 const logger = createLogger(LogLevel.INFO, "GetSandboxSessionOrThrow");
 
-export async function getSandboxSessionOrThrow(
+export function getSandboxSessionOrThrow(
   input: Record<string, unknown>,
-): Promise<Sandbox> {
+): Sandbox {
   let sandboxSessionId = "";
-  // Attempt to extract from input.
   if ("xSandboxSessionId" in input && input.xSandboxSessionId) {
     sandboxSessionId = input.xSandboxSessionId as string;
   } else {
@@ -23,6 +22,12 @@ export async function getSandboxSessionOrThrow(
     throw new Error("FAILED TO RUN COMMAND: No sandbox session ID provided");
   }
 
-  const sandbox = await daytonaClient().get(sandboxSessionId);
+  const sandbox = getSandbox(sandboxSessionId);
+  if (!sandbox) {
+    logger.error("FAILED TO RUN COMMAND: Sandbox not found", {
+      sandboxSessionId,
+    });
+    throw new Error("FAILED TO RUN COMMAND: Sandbox not found");
+  }
   return sandbox;
 }

--- a/apps/open-swe/src/utils/custom-rules.ts
+++ b/apps/open-swe/src/utils/custom-rules.ts
@@ -1,5 +1,5 @@
 import { CustomRules } from "@openswe/shared/open-swe/types";
-import { Sandbox } from "@daytonaio/sdk";
+import type { Sandbox } from "./sandbox.js";
 import { createLogger, LogLevel } from "./logger.js";
 import { getSandboxErrorFields } from "./sandbox-error-fields.js";
 import {

--- a/apps/open-swe/src/utils/env-setup.ts
+++ b/apps/open-swe/src/utils/env-setup.ts
@@ -1,4 +1,4 @@
-import { Sandbox } from "@daytonaio/sdk";
+import type { Sandbox } from "./sandbox.js";
 import { createLogger, LogLevel } from "./logger.js";
 import { TIMEOUT_SEC } from "@openswe/shared/constants";
 

--- a/apps/open-swe/src/utils/read-write.ts
+++ b/apps/open-swe/src/utils/read-write.ts
@@ -1,4 +1,4 @@
-import { Sandbox } from "@daytonaio/sdk";
+import type { Sandbox } from "./sandbox.js";
 import { createLogger, LogLevel } from "./logger.js";
 import { getSandboxErrorFields } from "./sandbox-error-fields.js";
 import { traceable } from "langsmith/traceable";

--- a/apps/open-swe/src/utils/sandbox-error-fields.ts
+++ b/apps/open-swe/src/utils/sandbox-error-fields.ts
@@ -1,4 +1,8 @@
-import { ExecuteResponse } from "@daytonaio/sdk/src/types/ExecuteResponse.js";
+export interface ExecuteResponse {
+  result?: string;
+  exitCode: number;
+  [key: string]: unknown;
+}
 
 export function getSandboxErrorFields(
   error: unknown,

--- a/apps/open-swe/src/utils/shell-executor/shell-executor.ts
+++ b/apps/open-swe/src/utils/shell-executor/shell-executor.ts
@@ -1,4 +1,4 @@
-import { Sandbox } from "@daytonaio/sdk";
+import type { Sandbox } from "../sandbox.js";
 import { GraphConfig } from "@openswe/shared/open-swe/types";
 import { TIMEOUT_SEC } from "@openswe/shared/constants";
 import {

--- a/apps/open-swe/src/utils/shell-executor/types.ts
+++ b/apps/open-swe/src/utils/shell-executor/types.ts
@@ -1,4 +1,4 @@
-import { Sandbox } from "@daytonaio/sdk";
+import type { Sandbox } from "../sandbox.js";
 
 export interface LocalExecuteResponse {
   exitCode: number;


### PR DESCRIPTION
## Summary
- replace Daytona usage with Docker client and sandbox helpers
- expose Docker-based command execution and lifecycle helpers
- add dockerode dependency

## Testing
- `npx prettier apps/open-swe/langbench/types.ts apps/open-swe/src/constants.ts apps/open-swe/src/graphs/reviewer/nodes/initialize-state.ts apps/open-swe/src/tools/apply-patch.ts apps/open-swe/src/tools/builtin-tools/handlers.ts apps/open-swe/src/tools/utils/get-sandbox-id.ts apps/open-swe/src/utils/custom-rules.ts apps/open-swe/src/utils/env-setup.ts apps/open-swe/src/utils/read-write.ts apps/open-swe/src/utils/sandbox-error-fields.ts apps/open-swe/src/utils/sandbox.ts apps/open-swe/src/utils/shell-executor/shell-executor.ts apps/open-swe/src/utils/shell-executor/types.ts --write`
- `cd apps/open-swe && npx eslint src/constants.ts src/graphs/reviewer/nodes/initialize-state.ts src/tools/apply-patch.ts src/tools/builtin-tools/handlers.ts src/tools/utils/get-sandbox-id.ts src/utils/custom-rules.ts src/utils/env-setup.ts src/utils/read-write.ts src/utils/sandbox-error-fields.ts src/utils/sandbox.ts src/utils/shell-executor/shell-executor.ts src/utils/shell-executor/types.ts --fix`
- `cd apps/open-swe && npx eslint langbench/types.ts --fix`
- `npm test` *(fails: Could not resolve workspaces / yarn not available)*

------
https://chatgpt.com/codex/tasks/task_e_68c17eb267788327a03485835568dd58