### PR TITLE
Track reasoning token metrics in cache reporting

### DIFF
--- a/apps/open-swe/src/utils/caching.ts
+++ b/apps/open-swe/src/utils/caching.ts
@@ -32,6 +32,10 @@ export function trackCachePerformance(
       response.usage_metadata?.input_token_details?.cache_read || 0,
     inputTokens: response.usage_metadata?.input_tokens || 0,
     outputTokens: response.usage_metadata?.output_tokens || 0,
+    reasoningTokens:
+      response.usage_metadata?.completion_tokens_details?.reasoning_tokens ||
+      response.usage_metadata?.output_token_details?.reasoning_tokens ||
+      0,
   };
 
   const totalInputTokens =

--- a/apps/web/src/components/v2/token-usage.tsx
+++ b/apps/web/src/components/v2/token-usage.tsx
@@ -16,6 +16,7 @@ import {
   CollapsibleTrigger,
 } from "../ui/collapsible";
 import {
+  Brain,
   ChartNoAxesColumnIncreasing,
   ChevronDown,
   ChevronRight,
@@ -46,12 +47,14 @@ function mergeTokenData(
         merged.cacheReadInputTokens + current.cacheReadInputTokens,
       inputTokens: merged.inputTokens + current.inputTokens,
       outputTokens: merged.outputTokens + current.outputTokens,
+      reasoningTokens: merged.reasoningTokens + current.reasoningTokens,
     }),
     {
       cacheCreationInputTokens: 0,
       cacheReadInputTokens: 0,
       inputTokens: 0,
       outputTokens: 0,
+      reasoningTokens: 0,
     },
   );
 }
@@ -194,6 +197,7 @@ export function TokenUsage({ tokenData }: TokenUsageProps) {
   if (!tokenData || tokenData.length === 0) return null;
 
   const mergedTokenData = mergeTokenData(tokenData);
+  const hasReasoningTokens = mergedTokenData.reasoningTokens > 0;
   const totalCachedInputTokens =
     mergedTokenData.cacheCreationInputTokens +
     mergedTokenData.cacheReadInputTokens;
@@ -237,7 +241,9 @@ export function TokenUsage({ tokenData }: TokenUsageProps) {
             <h4 className="text-sm font-semibold">Token Usage</h4>
           </div>
 
-          <div className="grid grid-cols-2 gap-4">
+          <div
+            className={`grid gap-4 ${hasReasoningTokens ? "grid-cols-3" : "grid-cols-2"}`}
+          >
             <div className="space-y-1">
               <div className="flex items-center gap-1.5">
                 <Zap className="h-3 w-3 text-blue-500 dark:text-blue-400" />
@@ -260,6 +266,19 @@ export function TokenUsage({ tokenData }: TokenUsageProps) {
                 {metrics.totalOutputTokens.toLocaleString()}
               </p>
             </div>
+            {hasReasoningTokens && (
+              <div className="space-y-1">
+                <div className="flex items-center gap-1.5">
+                  <Brain className="h-3 w-3 text-purple-500 dark:text-purple-400" />
+                  <span className="text-muted-foreground text-xs font-medium">
+                    Reasoning
+                  </span>
+                </div>
+                <p className="text-sm font-semibold">
+                  {metrics.totalReasoningTokens.toLocaleString()}
+                </p>
+              </div>
+            )}
           </div>
 
           <Separator />
@@ -341,7 +360,8 @@ export function TokenUsage({ tokenData }: TokenUsageProps) {
                       model.inputTokens +
                       model.outputTokens +
                       model.cacheCreationInputTokens +
-                      model.cacheReadInputTokens;
+                      model.cacheReadInputTokens +
+                      model.reasoningTokens;
                     const modelCachedTokens =
                       model.cacheCreationInputTokens +
                       model.cacheReadInputTokens;
@@ -397,6 +417,19 @@ export function TokenUsage({ tokenData }: TokenUsageProps) {
                               {model.outputTokens.toLocaleString()}
                             </span>
                           </div>
+                          {model.reasoningTokens > 0 && (
+                            <div className="flex justify-between">
+                              <div className="flex items-center gap-1.5">
+                                <Brain className="h-3 w-3 text-purple-500 dark:text-purple-400" />
+                                <span className="text-muted-foreground font-medium">
+                                  Reasoning
+                                </span>
+                              </div>
+                              <span className="font-semibold">
+                                {model.reasoningTokens.toLocaleString()}
+                              </span>
+                            </div>
+                          )}
                         </div>
 
                         {modelCachedTokens > 0 && (

--- a/packages/shared/src/__tests__/caching.test.ts
+++ b/packages/shared/src/__tests__/caching.test.ts
@@ -10,6 +10,7 @@ describe("tokenDataReducer", () => {
         cacheReadInputTokens: 50,
         inputTokens: 200,
         outputTokens: 150,
+        reasoningTokens: 40,
       },
       {
         model: "openai:gpt-4.1-mini",
@@ -17,6 +18,7 @@ describe("tokenDataReducer", () => {
         cacheReadInputTokens: 30,
         inputTokens: 120,
         outputTokens: 90,
+        reasoningTokens: 15,
       },
     ];
 
@@ -27,6 +29,7 @@ describe("tokenDataReducer", () => {
         cacheReadInputTokens: 15,
         inputTokens: 75,
         outputTokens: 60,
+        reasoningTokens: 10,
       },
       {
         model: "openai:gpt-3.5-turbo",
@@ -34,6 +37,7 @@ describe("tokenDataReducer", () => {
         cacheReadInputTokens: 20,
         inputTokens: 100,
         outputTokens: 80,
+        reasoningTokens: 8,
       },
     ];
 
@@ -52,6 +56,7 @@ describe("tokenDataReducer", () => {
       cacheReadInputTokens: 65, // 50 + 15
       inputTokens: 275, // 200 + 75
       outputTokens: 210, // 150 + 60
+      reasoningTokens: 50, // 40 + 10
     });
 
     // Find the unchanged openai gpt-4.1-mini model
@@ -64,6 +69,7 @@ describe("tokenDataReducer", () => {
       cacheReadInputTokens: 30,
       inputTokens: 120,
       outputTokens: 90,
+      reasoningTokens: 15,
     });
 
     // Find the new openai gpt-3.5-turbo model
@@ -76,6 +82,7 @@ describe("tokenDataReducer", () => {
       cacheReadInputTokens: 20,
       inputTokens: 100,
       outputTokens: 80,
+      reasoningTokens: 8,
     });
   });
 
@@ -87,6 +94,7 @@ describe("tokenDataReducer", () => {
         cacheReadInputTokens: 50,
         inputTokens: 200,
         outputTokens: 150,
+        reasoningTokens: 20,
       },
     ];
 
@@ -103,6 +111,7 @@ describe("tokenDataReducer", () => {
         cacheReadInputTokens: 50,
         inputTokens: 200,
         outputTokens: 150,
+        reasoningTokens: 5,
       },
     ];
 
@@ -119,6 +128,7 @@ describe("tokenDataReducer", () => {
         cacheReadInputTokens: 50,
         inputTokens: 200,
         outputTokens: 150,
+        reasoningTokens: 40,
       },
     ];
 
@@ -129,6 +139,7 @@ describe("tokenDataReducer", () => {
         cacheReadInputTokens: 15,
         inputTokens: 75,
         outputTokens: 60,
+        reasoningTokens: 12,
       },
       {
         model: "anthropic:claude-sonnet-4-0",
@@ -136,6 +147,7 @@ describe("tokenDataReducer", () => {
         cacheReadInputTokens: 5,
         inputTokens: 30,
         outputTokens: 20,
+        reasoningTokens: 3,
       },
     ];
 
@@ -148,6 +160,7 @@ describe("tokenDataReducer", () => {
       cacheReadInputTokens: 70, // 50 + 15 + 5
       inputTokens: 305, // 200 + 75 + 30
       outputTokens: 230, // 150 + 60 + 20
+      reasoningTokens: 55, // 40 + 12 + 3
     });
   });
 });

--- a/packages/shared/src/caching.ts
+++ b/packages/shared/src/caching.ts
@@ -7,6 +7,7 @@ export function calculateCostSavings(metrics: CacheMetrics): {
   totalInputTokens: number;
   totalOutputTokens: number;
   totalOutputTokensCost: number;
+  totalReasoningTokens: number;
 } {
   const SONNET_4_BASE_RATE = 3.0 / 1_000_000; // $3 per MTok
   const SONNET_4_OUTPUT_RATE = 15.0 / 1_000_000; // $15 per MTok
@@ -31,7 +32,9 @@ export function calculateCostSavings(metrics: CacheMetrics): {
     metrics.cacheCreationInputTokens +
     metrics.cacheReadInputTokens +
     metrics.inputTokens;
-  const totalTokens = totalInputTokens + metrics.outputTokens;
+  const totalReasoningTokens = metrics.reasoningTokens;
+  const totalTokens =
+    totalInputTokens + metrics.outputTokens + totalReasoningTokens;
   const costWithoutCaching = totalInputTokens * SONNET_4_BASE_RATE;
 
   // Actual cost with caching
@@ -44,6 +47,7 @@ export function calculateCostSavings(metrics: CacheMetrics): {
     totalInputTokens,
     totalOutputTokens: metrics.outputTokens,
     totalOutputTokensCost,
+    totalReasoningTokens,
   };
 }
 
@@ -76,6 +80,7 @@ export function tokenDataReducer(
           existing.cacheReadInputTokens + data.cacheReadInputTokens,
         inputTokens: existing.inputTokens + data.inputTokens,
         outputTokens: existing.outputTokens + data.outputTokens,
+        reasoningTokens: existing.reasoningTokens + data.reasoningTokens,
       });
     } else {
       // Add new model data

--- a/packages/shared/src/open-swe/types.ts
+++ b/packages/shared/src/open-swe/types.ts
@@ -23,6 +23,7 @@ export interface CacheMetrics {
   cacheReadInputTokens: number;
   inputTokens: number;
   outputTokens: number;
+  reasoningTokens: number;
 }
 
 export interface ModelTokenData extends CacheMetrics {


### PR DESCRIPTION
## Summary
- add reasoning token counts to shared cache metric types and reducer
- surface reasoning token usage in cache tracking and the token usage UI
- update caching reducer tests to cover reasoning token aggregation

## Testing
- yarn lint:fix
- yarn workspace @openswe/shared test:single packages/shared/src/__tests__/caching.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68c976298aa08327a83556a780d05a02