### PR TITLE
feat: centralize sandbox image configuration

### DIFF
--- a/apps/open-swe/evals/evaluator.ts
+++ b/apps/open-swe/evals/evaluator.ts
@@ -14,6 +14,7 @@ import { getRepoAbsolutePath } from "@openswe/shared/git";
 import { SimpleEvaluationResult } from "langsmith/vitest";
 import { runRuffLint, runMyPyTypeCheck } from "./tests.js";
 import { setupEnv, ENV_CONSTANTS } from "../src/utils/env-setup.js";
+import { SANDBOX_DOCKER_IMAGE } from "../src/constants.js";
 
 const logger = createLogger(LogLevel.INFO, "Evaluator ");
 
@@ -108,8 +109,7 @@ export async function evaluator(inputs: {
     user_input: openSWEInputs.user_input.substring(0, 100) + "...",
   });
 
-  const image = process.env.OPEN_SWE_SANDBOX_IMAGE || "node:18";
-  const sandbox = await createDockerSandbox(image);
+  const sandbox = await createDockerSandbox(SANDBOX_DOCKER_IMAGE);
 
   try {
     const localRepoDir = getRepoAbsolutePath(output.targetRepository);

--- a/apps/open-swe/langbench/evaluator.eval.ts
+++ b/apps/open-swe/langbench/evaluator.eval.ts
@@ -14,6 +14,7 @@ import { setupEnv } from "../src/utils/env-setup.js";
 import { uploadRepoToContainer } from "@openswe/shared/upload-repo-to-container";
 import { PRData, PRProcessResult } from "./types.js";
 import { runPytestOnFiles } from "./utils.js";
+import { SANDBOX_DOCKER_IMAGE } from "../src/constants.js";
 
 dotenv.config();
 
@@ -50,8 +51,7 @@ async function processPR(prData: PRData): Promise<PRProcessResult> {
     const testFiles = prData.testFiles || [];
     result.testFiles = testFiles;
     // Create sandbox
-    const image = process.env.OPEN_SWE_SANDBOX_IMAGE || "node:18";
-    sandbox = await createDockerSandbox(image);
+    sandbox = await createDockerSandbox(SANDBOX_DOCKER_IMAGE);
     result.workspaceId = sandbox.id;
     logger.info(`Created sandbox: ${sandbox.id}`);
 

--- a/apps/open-swe/src/constants.ts
+++ b/apps/open-swe/src/constants.ts
@@ -15,6 +15,11 @@ const DEFAULT_SANDBOX_PATH =
     : CONTAINER_PROJECT_ROOT) ||
   mkdtempSync(path.join(os.tmpdir(), "open-swe-"));
 
+const DEFAULT_SANDBOX_IMAGE = "node:20";
+
+export const SANDBOX_DOCKER_IMAGE =
+  process.env.OPEN_SWE_SANDBOX_IMAGE?.trim() || DEFAULT_SANDBOX_IMAGE;
+
 export const DEFAULT_SANDBOX_CREATE_PARAMS = {
   user: "open-swe",
   autoDeleteInterval: 15,

--- a/apps/open-swe/src/graphs/shared/initialize-sandbox.ts
+++ b/apps/open-swe/src/graphs/shared/initialize-sandbox.ts
@@ -10,6 +10,7 @@ import { getCodebaseTree } from "../../utils/tree.js";
 import { createDockerSandbox } from "../../utils/sandbox.js";
 import { uploadRepoToContainer } from "@openswe/shared/upload-repo-to-container";
 import { createShellExecutor } from "../../utils/shell-executor/index.js";
+import { SANDBOX_DOCKER_IMAGE } from "../../constants.js";
 import { DO_NOT_RENDER_ID_PREFIX } from "@openswe/shared/constants";
 import {
   CustomNodeEvent,
@@ -234,8 +235,7 @@ async function initializeSandboxRemote(
   let sandbox;
   const repoPath = getLocalWorkingDirectory();
   try {
-    const image = process.env.OPEN_SWE_SANDBOX_IMAGE || "node:18";
-    sandbox = await createDockerSandbox(image);
+    sandbox = await createDockerSandbox(SANDBOX_DOCKER_IMAGE);
     emitStepEvent(
       {
         ...createSandboxAction,

--- a/apps/open-swe/src/utils/sandbox.ts
+++ b/apps/open-swe/src/utils/sandbox.ts
@@ -1,6 +1,7 @@
 import Docker from "dockerode";
 import Stream from "node:stream";
 import { createLogger, LogLevel } from "./logger.js";
+import { SANDBOX_DOCKER_IMAGE } from "../constants.js";
 import { GraphConfig, TargetRepository } from "@openswe/shared/open-swe/types";
 import {
   isLocalMode,
@@ -154,7 +155,7 @@ export async function getSandboxWithErrorHandling(
       };
     }
   }
-  const image = process.env.OPEN_SWE_SANDBOX_IMAGE || "node:18";
+  const image = SANDBOX_DOCKER_IMAGE;
   const repoPath = getLocalWorkingDirectory();
   const sandbox = await createDockerSandbox(image);
   await uploadRepoToContainer({


### PR DESCRIPTION
## Summary
- default the sandbox Docker image to Node 20 and allow overrides via OPEN_SWE_SANDBOX_IMAGE
- update sandbox utilities and evaluators to use the centralized image configuration

## Testing
- yarn lint:fix
- yarn format

------
https://chatgpt.com/codex/tasks/task_e_68c97d6161d88327976bdff2538d2d04