### PR TITLE
Handle Docker connection failures gracefully

### DIFF
--- a/packages/shared/src/upload-repo-to-container.ts
+++ b/packages/shared/src/upload-repo-to-container.ts
@@ -14,6 +14,21 @@ export async function uploadRepoToContainer({
   containerPath = "/workspace",
 }: UploadOptions): Promise<void> {
   const docker = new Docker();
+  try {
+    await docker.ping();
+  } catch (error) {
+    const detail =
+      error instanceof Error
+        ? error.message
+        : typeof error === "string"
+          ? error
+          : "";
+    const suffix =
+      detail && detail !== "[object Object]" ? ` Details: ${detail}` : "";
+    throw new Error(
+      `Docker daemon not running or unreachable. Please start Docker and try again.${suffix}`,
+    );
+  }
   const container = docker.getContainer(containerId);
   const repoName = path.basename(localRepoPath);
   const tarStream = spawn("tar", [


### PR DESCRIPTION
## Summary
- ensure the sandbox Docker client verifies connectivity before use and provide a clear error when unavailable
- update sandbox lifecycle helpers to await the verified client instance
- guard repository upload against missing Docker daemons with actionable messaging

## Testing
- yarn format
- yarn lint:fix

------
https://chatgpt.com/codex/tasks/task_e_68c98561ddcc8327bf82dc58655075c7