### PR TITLE
feat: add sandbox docker image

### DIFF
--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -1,0 +1,34 @@
+# syntax=docker/dockerfile:1
+FROM node:20
+
+# Install core development tooling required by Open SWE sandboxes
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    bash \
+    build-essential \
+    ca-certificates \
+    curl \
+    git \
+    jq \
+    locales \
+    openssh-client \
+    python3 \
+    python3-pip \
+    python3-venv \
+    unzip \
+    wget \
+    zip \
+  && rm -rf /var/lib/apt/lists/*
+
+# Enable Corepack and provision Yarn 3.5.1
+RUN corepack enable \
+  && corepack prepare yarn@3.5.1 --activate
+
+# Prepare workspace directory used by Open SWE when mounting repositories
+RUN mkdir -p /workspace/project \
+  && chown -R node:node /workspace
+
+USER node
+WORKDIR /workspace
+
+ENV PATH="/home/node/.yarn/bin:$PATH"

--- a/README.md
+++ b/README.md
@@ -45,6 +45,22 @@ Open SWE runs locally without any external repository-hosting dependencies or au
 
 When not in local mode, the sandbox environment clones repositories under `/workspace/project` inside the container.
 
+### Sandbox image
+
+Open SWE executes tasks inside a sandbox Docker container. Before running local tasks, ensure you have the latest sandbox image available:
+
+```bash
+docker pull ghcr.io/langchain-ai/open-swe/sandbox:latest
+```
+
+If you prefer to build the image yourself, use the dedicated sandbox Dockerfile:
+
+```bash
+docker build -f Dockerfile.sandbox -t ghcr.io/langchain-ai/open-swe/sandbox:latest .
+```
+
+The agent uses this image by default via the `OPEN_SWE_SANDBOX_IMAGE` environment variable, which now defaults to `ghcr.io/langchain-ai/open-swe/sandbox:latest`.
+
 
 For the Azure OpenAI API version, set `AZURE_OPENAI_API_VERSION` (preferred) or `OPENAI_API_VERSION`. The agent will use `AZURE_OPENAI_API_VERSION` when available and fall back to `OPENAI_API_VERSION` otherwise.
 

--- a/apps/docs/setup/intro.mdx
+++ b/apps/docs/setup/intro.mdx
@@ -40,6 +40,22 @@ Open SWE is built with modern technologies designed for scalability and develope
   - Programmer graph for code change execution
 - **Local sandbox** - Sandboxed development environments for safe code execution
 
+## Sandbox image prerequisite
+
+Open SWE executes repositories inside a sandbox Docker container. Before starting local tasks, make sure the sandbox image is available on your machine:
+
+```bash
+docker pull ghcr.io/langchain-ai/open-swe/sandbox:latest
+```
+
+You can also build the image locally using the dedicated Dockerfile provided in the repository root:
+
+```bash
+docker build -f Dockerfile.sandbox -t ghcr.io/langchain-ai/open-swe/sandbox:latest .
+```
+
+The agent uses this image by default via the `OPEN_SWE_SANDBOX_IMAGE` environment variable, so keeping it up to date ensures consistent tooling when the sandbox is created.
+
 ### Web Application
 
 - **Next.js** - React framework with App Router

--- a/apps/open-swe/src/constants.ts
+++ b/apps/open-swe/src/constants.ts
@@ -15,7 +15,7 @@ const DEFAULT_SANDBOX_PATH =
     : CONTAINER_PROJECT_ROOT) ||
   mkdtempSync(path.join(os.tmpdir(), "open-swe-"));
 
-const DEFAULT_SANDBOX_IMAGE = "node:20";
+const DEFAULT_SANDBOX_IMAGE = "ghcr.io/langchain-ai/open-swe/sandbox:latest";
 
 export const SANDBOX_DOCKER_IMAGE =
   process.env.OPEN_SWE_SANDBOX_IMAGE?.trim() || DEFAULT_SANDBOX_IMAGE;

--- a/apps/open-swe/src/utils/caching.ts
+++ b/apps/open-swe/src/utils/caching.ts
@@ -25,16 +25,37 @@ export function trackCachePerformance(
   response: AIMessageChunk,
   model: string,
 ): ModelTokenData[] {
+  const completionTokenDetails =
+    response.usage_metadata &&
+    "completion_tokens_details" in response.usage_metadata
+      ? (response.usage_metadata as typeof response.usage_metadata & {
+          completion_tokens_details?: { reasoning_tokens?: number };
+        }).completion_tokens_details
+      : undefined;
+
+  const inputTokenDetails =
+    response.usage_metadata?.input_token_details as
+      | {
+          cache_creation?: number;
+          cache_read?: number;
+        }
+      | undefined;
+
+  const outputTokenDetails =
+    response.usage_metadata?.output_token_details as
+      | {
+          reasoning_tokens?: number;
+        }
+      | undefined;
+
   const metrics: CacheMetrics = {
-    cacheCreationInputTokens:
-      response.usage_metadata?.input_token_details?.cache_creation || 0,
-    cacheReadInputTokens:
-      response.usage_metadata?.input_token_details?.cache_read || 0,
+    cacheCreationInputTokens: inputTokenDetails?.cache_creation || 0,
+    cacheReadInputTokens: inputTokenDetails?.cache_read || 0,
     inputTokens: response.usage_metadata?.input_tokens || 0,
     outputTokens: response.usage_metadata?.output_tokens || 0,
     reasoningTokens:
-      response.usage_metadata?.completion_tokens_details?.reasoning_tokens ||
-      response.usage_metadata?.output_token_details?.reasoning_tokens ||
+      completionTokenDetails?.reasoning_tokens ||
+      outputTokenDetails?.reasoning_tokens ||
       0,
   };
 

--- a/apps/open-swe/src/utils/sandbox.ts
+++ b/apps/open-swe/src/utils/sandbox.ts
@@ -108,15 +108,22 @@ export async function createDockerSandbox(
   mountPath = "/workspace",
 ): Promise<Sandbox> {
   const docker = await dockerClient();
+  const hostConfig: Docker.ContainerCreateOptions["HostConfig"] = {
+    Memory: SANDBOX_MEMORY_LIMIT_BYTES,
+  };
+
+  if (SANDBOX_NANO_CPUS > 0) {
+    (hostConfig as Docker.ContainerCreateOptions["HostConfig"] & {
+      NanoCPUs?: number;
+    }).NanoCPUs = SANDBOX_NANO_CPUS;
+  }
+
   const container = await docker.createContainer({
     Image: image,
     Tty: true,
     Cmd: ["/bin/sh", "-c", "while true; do sleep 3600; done"],
     Env: [`SANDBOX_ROOT_DIR=${mountPath}`],
-    HostConfig: {
-      Memory: SANDBOX_MEMORY_LIMIT_BYTES,
-      NanoCPUs: SANDBOX_NANO_CPUS,
-    },
+    HostConfig: hostConfig,
     NetworkDisabled: SANDBOX_NETWORK_DISABLED,
     User: SANDBOX_USER,
   });


### PR DESCRIPTION
## Summary
- add a dedicated `Dockerfile.sandbox` based on `node:20` with git, yarn 3.5.1, and supporting CLI tools
- point the default sandbox image to `ghcr.io/langchain-ai/open-swe/sandbox:latest` and fix strict type usage in sandbox utilities
- document pulling or building the sandbox image before running local tasks in the README and setup docs

## Testing
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_68c9871a81b48327a52bc0dd42422d6b