### PR TITLE
Add sandbox Dockerfile for language toolchain

### DIFF
--- a/docker/sandbox/Dockerfile
+++ b/docker/sandbox/Dockerfile
@@ -1,0 +1,51 @@
+# syntax=docker/dockerfile:1
+FROM ubuntu:22.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG USERNAME=dev
+ARG USER_UID=1000
+ARG USER_GID=1000
+
+# Install dependencies and tools
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        gnupg \
+        software-properties-common \
+        unzip \
+        build-essential \
+        git \
+    && add-apt-repository ppa:deadsnakes/ppa \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        python3.11 \
+        python3.11-distutils \
+        python3.11-venv \
+        python3.11-dev \
+        openjdk-21-jdk \
+    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && apt-get install -y --no-install-recommends maven gradle \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install pip for Python 3.11 and Python tooling
+RUN curl -fsSL https://bootstrap.pypa.io/get-pip.py | python3.11 \
+    && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1 \
+    && update-alternatives --install /usr/bin/python python /usr/bin/python3.11 1 \
+    && python -m pip install --no-cache-dir --upgrade pip setuptools wheel pytest
+
+# Enable Corepack and install JavaScript tooling
+RUN corepack enable \
+    && corepack prepare pnpm@latest --activate \
+    && npm install -g ts-node eslint
+
+# Create non-root user with /workspace home directory
+RUN groupadd --gid ${USER_GID} ${USERNAME} \
+    && useradd --uid ${USER_UID} --gid ${USER_GID} --create-home --home-dir /workspace --shell /bin/bash ${USERNAME}
+
+ENV PATH="/workspace/.local/bin:${PATH}"
+WORKDIR /workspace
+USER ${USERNAME}
+
+CMD ["bash"]


### PR DESCRIPTION
## Summary
- add a sandbox Dockerfile that installs JDK 21, Python 3.11, Node.js 20, and associated tooling
- configure pnpm, ts-node, pytest, eslint, Maven, and Gradle for global use
- create a non-root /workspace user ready for development tasks

## Testing
- not run (docker command unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68d5ae2379508327b6abfb4d58c3d632