### PR TITLE
feat: add sandbox core type interfaces

### DIFF
--- a/packages/sandbox-core/package.json
+++ b/packages/sandbox-core/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@openswe/sandbox-core",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "clean": "rm -rf ./dist .turbo || true",
+    "build": "yarn clean && tsc -p tsconfig.json"
+  },
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
+    },
+    "./*": {
+      "types": "./dist/*.d.ts",
+      "import": "./dist/*.js",
+      "require": "./dist/*.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist/**/*"
+  ]
+}

--- a/packages/sandbox-core/src/index.ts
+++ b/packages/sandbox-core/src/index.ts
@@ -1,0 +1,1 @@
+export type { ExecResult, SandboxHandle, SandboxProvider } from "./types.js";

--- a/packages/sandbox-core/src/types.ts
+++ b/packages/sandbox-core/src/types.ts
@@ -1,0 +1,29 @@
+export interface ExecResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  result: string;
+  artifacts?: {
+    stdout: string;
+    stderr: string;
+  };
+}
+
+export interface SandboxHandle {
+  id: string;
+  process: {
+    executeCommand(
+      command: string,
+      cwd?: string,
+      env?: Record<string, string>,
+      timeoutSec?: number,
+    ): Promise<ExecResult>;
+  };
+}
+
+export interface SandboxProvider {
+  createSandbox(image: string, mountPath?: string): Promise<SandboxHandle>;
+  getSandbox(id: string): SandboxHandle | undefined;
+  stopSandbox(id: string): Promise<string>;
+  deleteSandbox(id: string): Promise<boolean>;
+}

--- a/packages/sandbox-core/tsconfig.json
+++ b/packages/sandbox-core/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3293,6 +3293,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@openswe/sandbox-core@workspace:packages/sandbox-core":
+  version: 0.0.0-use.local
+  resolution: "@openswe/sandbox-core@workspace:packages/sandbox-core"
+  languageName: unknown
+  linkType: soft
+
 "@openswe/shared@*, @openswe/shared@workspace:packages/shared":
   version: 0.0.0-use.local
   resolution: "@openswe/shared@workspace:packages/shared"


### PR DESCRIPTION
## Summary
- add the @openswe/sandbox-core workspace for reusable sandbox types
- define ExecResult, SandboxHandle, and SandboxProvider interfaces and re-export them from the package entrypoint
- configure package metadata and TypeScript project settings for the new workspace

## Testing
- yarn build
- yarn lint:fix
- yarn format

------
https://chatgpt.com/codex/tasks/task_e_68d5af117ccc8327b58d7774a85fd386