### PR TITLE
feat: add sandbox command runners

### DIFF
--- a/apps/open-swe/evals/tests.ts
+++ b/apps/open-swe/evals/tests.ts
@@ -7,6 +7,7 @@ import {
   RuffIssue,
   MyPyResult,
 } from "./open-swe-types.js";
+import { execInSandbox } from "@openswe/sandbox-core/runners";
 
 const logger = createLogger(LogLevel.DEBUG, " Evaluation Tests");
 
@@ -20,12 +21,11 @@ export const runRuffLint = async (
   logger.info("Running ruff check...");
 
   try {
-    const execution = await sandbox.process.executeCommand(
-      args.command,
-      args.workingDir,
-      args.env,
-      args.timeoutSec,
-    );
+    const execution = await execInSandbox(sandbox, args.command, {
+      cwd: args.workingDir,
+      env: args.env,
+      timeoutSec: args.timeoutSec,
+    });
 
     if (execution.exitCode === 0) {
       logger.info("Ruff analysis passed. No issues found.");
@@ -85,12 +85,11 @@ export const runMyPyTypeCheck = async (
 ): Promise<MyPyResult> => {
   logger.info("Running mypy check...");
   try {
-    const execution = await sandbox.process.executeCommand(
-      args.command,
-      args.workingDir,
-      args.env,
-      args.timeoutSec,
-    );
+    const execution = await execInSandbox(sandbox, args.command, {
+      cwd: args.workingDir,
+      env: args.env,
+      timeoutSec: args.timeoutSec,
+    });
 
     if (execution.exitCode === 0) {
       logger.info("Mypy analysis passed. No issues found.");

--- a/apps/open-swe/src/utils/sandbox.ts
+++ b/apps/open-swe/src/utils/sandbox.ts
@@ -8,7 +8,7 @@ import type {
   LocalDockerSandboxResources,
   WritableMount,
 } from "@openswe/sandbox-docker";
-import type { SandboxHandle } from "@openswe/sandbox-core";
+import type { SandboxHandle, SandboxProvider } from "@openswe/sandbox-core";
 import { GraphConfig, TargetRepository } from "@openswe/shared/open-swe/types";
 import {
   isLocalMode,
@@ -21,7 +21,7 @@ const logger = createLogger(LogLevel.INFO, "Sandbox");
 
 type SandboxProviderFactory = (
   options: LocalDockerSandboxOptions,
-) => LocalDockerSandboxProvider;
+) => SandboxProvider;
 
 const DEFAULT_REPO_ROOT = "/workspace";
 const DEFAULT_COMMIT_MESSAGE = "OpenSWE auto-commit";
@@ -215,7 +215,7 @@ export type SandboxProcess = SandboxHandle["process"];
 export type Sandbox = SandboxHandle;
 
 interface SandboxMetadata {
-  provider: LocalDockerSandboxProvider;
+  provider: SandboxProvider;
   hostRepoPath?: string;
   containerRepoPath: string;
   commitOnChange: boolean;

--- a/packages/sandbox-core/src/index.ts
+++ b/packages/sandbox-core/src/index.ts
@@ -1,1 +1,12 @@
-export type { ExecResult, SandboxHandle, SandboxProvider } from "./types.js";
+export type {
+  ExecResult,
+  SandboxExecOptions,
+  SandboxHandle,
+  SandboxProvider,
+} from "./types.js";
+export {
+  execInSandbox,
+  installNodeDeps,
+  runJavaTests,
+  runPythonTests,
+} from "./runners.js";

--- a/packages/sandbox-core/src/runners.ts
+++ b/packages/sandbox-core/src/runners.ts
@@ -1,0 +1,182 @@
+import type {
+  ExecResult,
+  SandboxExecOptions,
+  SandboxHandle,
+  SandboxProvider,
+} from "./types.js";
+
+export type SandboxCommandTarget =
+  | SandboxHandle
+  | {
+      sandbox: SandboxHandle;
+      provider?: SandboxProvider;
+    }
+  | {
+      sandboxId: string;
+      provider: SandboxProvider;
+    };
+
+function isSandboxHandle(target: SandboxCommandTarget | SandboxHandle): target is SandboxHandle {
+  return typeof (target as SandboxHandle)?.process?.executeCommand === "function";
+}
+
+function resolveProvider(
+  target: SandboxCommandTarget,
+): {
+  sandboxHandle?: SandboxHandle;
+  sandboxId: string;
+  provider?: SandboxProvider;
+} {
+  if (isSandboxHandle(target)) {
+    return { sandboxHandle: target, sandboxId: target.id };
+  }
+
+  if ("sandbox" in target) {
+    return {
+      sandboxHandle: target.sandbox,
+      sandboxId: target.sandbox.id,
+      provider: target.provider,
+    };
+  }
+
+  return {
+    sandboxId: target.sandboxId,
+    provider: target.provider,
+  };
+}
+
+export async function execInSandbox(
+  target: SandboxCommandTarget,
+  command: string,
+  options: SandboxExecOptions = {},
+): Promise<ExecResult> {
+  const { sandboxHandle, sandboxId, provider } = resolveProvider(target);
+  if (provider) {
+    return await provider.exec(sandboxHandle ?? sandboxId, command, options);
+  }
+
+  if (!sandboxHandle) {
+    throw new Error(
+      "Sandbox handle is required when provider is not supplied to execInSandbox",
+    );
+  }
+
+  return await sandboxHandle.process.executeCommand(
+    command,
+    options.cwd,
+    options.env,
+    options.timeoutSec,
+  );
+}
+
+type NodePackageManager = "npm" | "yarn" | "pnpm";
+
+export interface InstallNodeDepsOptions extends SandboxExecOptions {
+  packageManager?: NodePackageManager;
+  frozenLockfile?: boolean;
+  additionalArgs?: string[];
+  commandOverride?: string;
+}
+
+function buildNodeInstallCommand(options: InstallNodeDepsOptions = {}): string {
+  const packageManager = options.packageManager ?? "npm";
+  const args = options.additionalArgs ? [...options.additionalArgs] : [];
+
+  if (options.commandOverride) {
+    return options.commandOverride;
+  }
+
+  if (packageManager === "yarn" || packageManager === "pnpm") {
+    const command = [packageManager, "install"];
+    if (options.frozenLockfile) {
+      command.push("--frozen-lockfile");
+    }
+    command.push(...args);
+    return command.join(" ");
+  }
+
+  // npm specific handling - use npm ci when frozen lockfiles are desired
+  const subcommand = options.frozenLockfile ? "ci" : "install";
+  return ["npm", subcommand, ...args].join(" ");
+}
+
+export async function installNodeDeps(
+  target: SandboxCommandTarget,
+  options: InstallNodeDepsOptions = {},
+): Promise<ExecResult> {
+  const command = buildNodeInstallCommand(options);
+  return await execInSandbox(target, command, options);
+}
+
+export interface RunPythonTestsOptions extends SandboxExecOptions {
+  pythonPath?: string;
+  module?: string;
+  args?: string[];
+  files?: string[];
+  commandOverride?: string;
+}
+
+function buildPythonTestCommand(options: RunPythonTestsOptions = {}): string {
+  if (options.commandOverride) {
+    return options.commandOverride;
+  }
+
+  const pythonPath = options.pythonPath ?? "python";
+  const module = options.module ?? "pytest";
+  const args = options.args ? [...options.args] : [];
+  const files = options.files ? [...options.files] : [];
+
+  const commandParts = [pythonPath];
+  if (module) {
+    commandParts.push("-m", module);
+  }
+  commandParts.push(...args);
+  commandParts.push(...files);
+
+  return commandParts.join(" ");
+}
+
+export async function runPythonTests(
+  target: SandboxCommandTarget,
+  options: RunPythonTestsOptions = {},
+): Promise<ExecResult> {
+  const command = buildPythonTestCommand(options);
+  return await execInSandbox(target, command, options);
+}
+
+export interface RunJavaTestsOptions extends SandboxExecOptions {
+  buildTool?: "maven" | "gradle";
+  args?: string[];
+  useWrapper?: boolean;
+  commandOverride?: string;
+}
+
+function buildJavaTestCommand(options: RunJavaTestsOptions = {}): string {
+  if (options.commandOverride) {
+    return options.commandOverride;
+  }
+
+  const buildTool = options.buildTool ?? "maven";
+  const args = options.args ? [...options.args] : [];
+
+  if (buildTool === "gradle") {
+    const executable = options.useWrapper ?? true ? "./gradlew" : "gradle";
+    return [executable, "test", ...args].join(" ");
+  }
+
+  return ["mvn", "test", ...args].join(" ");
+}
+
+export async function runJavaTests(
+  target: SandboxCommandTarget,
+  options: RunJavaTestsOptions = {},
+): Promise<ExecResult> {
+  const command = buildJavaTestCommand(options);
+  return await execInSandbox(target, command, options);
+}
+
+export type {
+  InstallNodeDepsOptions as NodeDepsOptions,
+  RunPythonTestsOptions as PythonTestOptions,
+  RunJavaTestsOptions as JavaTestOptions,
+};

--- a/packages/sandbox-core/src/types.ts
+++ b/packages/sandbox-core/src/types.ts
@@ -9,6 +9,12 @@ export interface ExecResult {
   };
 }
 
+export interface SandboxExecOptions {
+  cwd?: string;
+  env?: Record<string, string>;
+  timeoutSec?: number;
+}
+
 export interface SandboxHandle {
   id: string;
   process: {
@@ -26,4 +32,9 @@ export interface SandboxProvider {
   getSandbox(id: string): SandboxHandle | undefined;
   stopSandbox(id: string): Promise<string>;
   deleteSandbox(id: string): Promise<boolean>;
+  exec(
+    target: SandboxHandle | string,
+    command: string,
+    options?: SandboxExecOptions,
+  ): Promise<ExecResult>;
 }


### PR DESCRIPTION
## Summary
- add sandbox runner utilities for installing dependencies and running language-specific tests
- update sandbox provider and agent orchestration code to use shared exec helpers
- expose new sandbox core exports and adjust tests for updated provider interface

## Testing
- yarn build
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68d6a294c0b08327ae85796ec5aeed74