### PR TITLE
Add local Docker Compose setup for UI and agent

### DIFF
--- a/compose.local.yaml
+++ b/compose.local.yaml
@@ -1,0 +1,55 @@
+x-open-swe-build: &openswe-build
+  context: .
+  dockerfile: Dockerfile
+
+services:
+  agent:
+    build: *openswe-build
+    image: open-swe:local
+    command: ["yarn", "workspace", "@openswe/agent", "dev"]
+    ports:
+      - "2024:2024"
+    environment:
+      OPEN_SWE_LOCAL_MODE: ${OPEN_SWE_LOCAL_MODE:-true}
+      OPEN_SWE_LOCAL_PROJECT_PATH: ${OPEN_SWE_LOCAL_PROJECT_PATH:-/workspaces}
+      OPEN_SWE_PROJECT_PATH: ${OPEN_SWE_PROJECT_PATH:-}
+      OPEN_SWE_SANDBOX_IMAGE: ${OPEN_SWE_SANDBOX_IMAGE:-ghcr.io/langchain-ai/open-swe/sandbox:latest}
+      OPEN_SWE_SANDBOX_MEMORY_BYTES: ${OPEN_SWE_SANDBOX_MEMORY_BYTES:-}
+      OPEN_SWE_SANDBOX_CPUS: ${OPEN_SWE_SANDBOX_CPUS:-}
+      OPEN_SWE_SANDBOX_NANO_CPUS: ${OPEN_SWE_SANDBOX_NANO_CPUS:-}
+      OPEN_SWE_SANDBOX_ENABLE_NETWORK: ${OPEN_SWE_SANDBOX_ENABLE_NETWORK:-true}
+      OPEN_SWE_SANDBOX_NETWORK_MODE: ${OPEN_SWE_SANDBOX_NETWORK_MODE:-}
+      OPEN_SWE_SANDBOX_TIMEOUT_SEC: ${OPEN_SWE_SANDBOX_TIMEOUT_SEC:-}
+      OPEN_SWE_SANDBOX_USER: ${OPEN_SWE_SANDBOX_USER:-}
+      OPEN_SWE_GIT_AUTHOR_NAME: ${OPEN_SWE_GIT_AUTHOR_NAME:-}
+      OPEN_SWE_GIT_AUTHOR_EMAIL: ${OPEN_SWE_GIT_AUTHOR_EMAIL:-}
+      OPEN_SWE_SANDBOX_GIT_USER_NAME: ${OPEN_SWE_SANDBOX_GIT_USER_NAME:-}
+      OPEN_SWE_SANDBOX_GIT_USER_EMAIL: ${OPEN_SWE_SANDBOX_GIT_USER_EMAIL:-}
+      AZURE_OPENAI_API_KEY: ${AZURE_OPENAI_API_KEY:-}
+      AZURE_OPENAI_ENDPOINT: ${AZURE_OPENAI_ENDPOINT:-}
+      AZURE_OPENAI_API_VERSION: ${AZURE_OPENAI_API_VERSION:-}
+      AZURE_OPENAI_DEPLOYMENT: ${AZURE_OPENAI_DEPLOYMENT:-}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      SANDBOX_ROOT_DIR: ${SANDBOX_ROOT_DIR:-}
+    volumes:
+      - ${WORKSPACES_ROOT:-.}:/workspaces:delegated
+      - /var/run/docker.sock:/var/run/docker.sock
+  ui:
+    build: *openswe-build
+    image: open-swe:local
+    command: ["yarn", "workspace", "@openswe/web", "dev"]
+    ports:
+      - "3000:3000"
+    environment:
+      NODE_ENV: ${NODE_ENV:-development}
+      OPEN_SWE_AGENT_BASE_URL: ${OPEN_SWE_AGENT_BASE_URL:-http://agent:2024}
+      AZURE_OPENAI_API_KEY: ${AZURE_OPENAI_API_KEY:-}
+      AZURE_OPENAI_ENDPOINT: ${AZURE_OPENAI_ENDPOINT:-}
+      AZURE_OPENAI_API_VERSION: ${AZURE_OPENAI_API_VERSION:-}
+      AZURE_OPENAI_DEPLOYMENT: ${AZURE_OPENAI_DEPLOYMENT:-}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+    depends_on:
+      - agent
+volumes: {}


### PR DESCRIPTION
## Summary
- add a local docker compose definition for the agent and ui services sharing the repo build context
- mount the docker socket and host workspace into the agent container and expose required environment variables

## Testing
- docker compose -f compose.local.yaml up --build *(fails: `docker: command not found` in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6a7646d548327829bd97a5503b92c