### PR TITLE
Add prohibited reference guard enforcement to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,23 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  guard:
+    name: Guard prohibited references
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Enable Corepack
+        run: corepack enable
+      - name: Use Node.js 18.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+          cache: "yarn"
+      - name: Install dependencies
+        run: yarn install --immutable --mode=skip-build
+      - name: Run prohibited reference guard
+        run: yarn guard:no-daytona
+
   format:
     name: Check formatting
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-langgraph.yml
+++ b/.github/workflows/deploy-langgraph.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable --mode=skip-build
 
+      - name: Run prohibited reference guard
+        run: yarn guard:no-daytona
+
       - name: Execute deployment
         run: |
           cd apps/open-swe

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -34,6 +34,8 @@ jobs:
           cache: "yarn"
       - name: Install dependencies
         run: yarn install --immutable --mode=skip-build
+      - name: Run prohibited reference guard
+        run: yarn guard:no-daytona
       - name: Build project
         run: yarn build
       - name: Run tests

--- a/scripts/guard-no-daytona.sh
+++ b/scripts/guard-no-daytona.sh
@@ -4,12 +4,40 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
-mapfile -t matches < <(rg -i "daytona" --files-with-matches --hidden --no-ignore --glob '!vendor/**' --glob '!node_modules/**' --glob '!scripts/guard-no-daytona.sh')
+declare -a forbidden_patterns=(
+  "daytona:Daytona"
+  "octokit:Octokit"
+  "api.github.com:GitHub API"
+)
 
-if ((${#matches[@]})); then
-  printf 'ERROR: Forbidden Daytona references found in:\n'
-  printf ' - %s\n' "${matches[@]}"
+declare -a hits=()
+
+for entry in "${forbidden_patterns[@]}"; do
+  pattern="${entry%%:*}"
+  label="${entry#*:}"
+
+  mapfile -t matches < <(rg -i "${pattern}" --files-with-matches --hidden --no-ignore --glob '!**/.git/**' --glob '!**/vendor/**' --glob '!**/node_modules/**' --glob '!scripts/guard-no-daytona.sh' || true)
+
+  if ((${#matches[@]})); then
+    for file in "${matches[@]}"; do
+      if [[ "${pattern}" == "daytona" ]]; then
+        if ! rg -in "${pattern}" "${file}" | rg -vi 'guard[-:]no-daytona' >/dev/null; then
+          continue
+        fi
+      fi
+      hits+=("${file}::${label}")
+    done
+  fi
+done
+
+if ((${#hits[@]})); then
+  printf 'ERROR: Forbidden references found in:\n'
+  for hit in "${hits[@]}"; do
+    file="${hit%%::*}"
+    label="${hit#*::}"
+    printf ' - %s (pattern: %s)\n' "$file" "$label"
+  done
   exit 1
 fi
 
-printf 'OK: No Daytona references.\n'
+printf 'OK: No forbidden references.\n'


### PR DESCRIPTION
## Summary
- add a dedicated guard job to the main CI workflow and run the guard step in the unit test and deploy pipelines
- extend the guard script to cover Octokit and GitHub API references while ignoring guard invocation strings

## Testing
- yarn guard:no-daytona
- yarn guard:no-daytona # (fails as expected when a temporary forbidden file is added)


------
https://chatgpt.com/codex/tasks/task_e_68d6b03be7748327a17efdfa8f016723