### PR TITLE
Include workspace absolute path in run requests

### DIFF
--- a/apps/web/src/app/api/local-repositories/route.ts
+++ b/apps/web/src/app/api/local-repositories/route.ts
@@ -11,7 +11,7 @@ export async function GET(request: NextRequest) {
 
     for (const entry of entries) {
       if (!entry.isDirectory()) continue;
-      const repoPath = path.join(baseDir, entry.name);
+      const repoPath = path.resolve(baseDir, entry.name);
       try {
         await stat(path.join(repoPath, ".git"));
         if (!search || entry.name.toLowerCase().includes(search)) {

--- a/packages/shared/src/open-swe/manager/types.ts
+++ b/packages/shared/src/open-swe/manager/types.ts
@@ -8,6 +8,10 @@ export const ManagerGraphStateObj = MessagesZodState.extend({
    * The target repository the request should be executed in.
    */
   targetRepository: z.custom<TargetRepository>(),
+  /**
+   * Absolute path to the user's selected workspace when running locally.
+   */
+  workspaceAbsPath: z.string().optional(),
   issueId: z.number().optional(),
   /**
    * The tasks generated for this request.


### PR DESCRIPTION
## Summary
- ensure the local repository listing resolves each repository path to an absolute directory
- pass the resolved workspace path through terminal submissions so runs include the local workspace
- add the optional workspace field to the manager graph state shared type for downstream use

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68d6b19217288327989a6f9577d3aad7