### PR TITLE
Improve sandbox safety and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ Open SWE runs locally without any external repository-hosting dependencies or au
 
 When not in local mode, the sandbox environment clones repositories under `/workspace/project` inside the container.
 
+### Docker Desktop file sharing (macOS & Windows)
+
+If you are using Docker Desktop, ensure the directory that contains this repository is shared before starting the stack. Open **Settings → Resources → File Sharing** and add the parent directory of the paths you intend to expose through `${WORKSPACES_ROOT}`. Restart Docker Desktop after updating the shared folders so that the agent container can mount your repositories without permission errors.
+
 ### Sandbox image
 
 Open SWE executes tasks inside a sandbox Docker container. Before running local tasks, ensure you have the latest sandbox image available:

--- a/docs/local-docker-sandbox.md
+++ b/docs/local-docker-sandbox.md
@@ -17,6 +17,15 @@ API key setup guides when configuring a new machine.
   create child sandboxes. Linux users should belong to the `docker` group or run the Compose
   stack with elevated privileges.
 
+### Docker Desktop file sharing (macOS & Windows)
+
+Docker Desktop restricts which host folders can be mounted into containers. Before starting the
+stack, open **Settings → Resources → File Sharing** and add the directory that contains your Open
+SWE checkout (for example, `C:\Users\<you>\code\open-swe` on Windows or `/Users/<you>/code/open-swe`
+on macOS). Ensure the parent directory of `${WORKSPACES_ROOT}` is shared—otherwise the agent cannot
+mount repositories selected in the UI. After applying the change, restart Docker Desktop so the
+newly shared path is available to Compose.
+
 ## Quickstart
 
 1. **Clone the repository and install dependencies.**

--- a/packages/sandbox-core/src/index.ts
+++ b/packages/sandbox-core/src/index.ts
@@ -3,6 +3,8 @@ export type {
   SandboxExecOptions,
   SandboxHandle,
   SandboxProvider,
+  SandboxMetadata,
+  SandboxResourceLimits,
 } from "./types.js";
 export {
   execInSandbox,

--- a/packages/sandbox-core/src/types.ts
+++ b/packages/sandbox-core/src/types.ts
@@ -15,8 +15,22 @@ export interface SandboxExecOptions {
   timeoutSec?: number;
 }
 
+export interface SandboxResourceLimits {
+  cpuCount?: number;
+  memoryBytes?: number;
+  pidsLimit?: number;
+}
+
+export interface SandboxMetadata {
+  containerId?: string;
+  containerName?: string;
+  requestedResources?: SandboxResourceLimits;
+  appliedResources?: SandboxResourceLimits;
+}
+
 export interface SandboxHandle {
   id: string;
+  metadata?: SandboxMetadata;
   process: {
     executeCommand(
       command: string,


### PR DESCRIPTION
## Summary
- enforce the shared 15 minute timeout in the local shell executor and surface friendly timeout results
- expose requested and applied Docker resource limits from sandbox handles and log the inspected values
- redact sensitive environment data from structured logs and add a regression test for symlink traversal
- document Docker Desktop file sharing requirements for macOS and Windows users

## Testing
- yarn workspace @openswe/agent test:single -- --runTestsByPath src/server/routes/__tests__/run.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d6d38aed2c8327beb97b21e248f890