### PR TITLE
Fix run route typing and workspace handlers

### DIFF
--- a/apps/open-swe/src/server/routes/__tests__/run.test.ts
+++ b/apps/open-swe/src/server/routes/__tests__/run.test.ts
@@ -102,7 +102,9 @@ describe("registerRunRoute", () => {
     });
 
     expect(response.status).toBe(200);
-    const body = await response.json();
+    const body = (await response.json()) as {
+      resolvedWorkspaceAbsPath: string;
+    };
     expect(body).toEqual({
       resolvedWorkspaceAbsPath: fs.realpathSync(workspace),
     });
@@ -121,7 +123,7 @@ describe("registerRunRoute", () => {
     });
 
     expect(response.status).toBe(500);
-    const body = await response.json();
+    const body = (await response.json()) as { error: string };
     expect(body.error).toBe("WORKSPACES_ROOT environment variable is not set.");
   });
 
@@ -140,7 +142,7 @@ describe("registerRunRoute", () => {
     });
 
     expect(response.status).toBe(400);
-    const body = await response.json();
+    const body = (await response.json()) as { error: string };
     expect(body.error).toBe(
       `Resolved workspace path "${fs.realpathSync(outside)}" is outside of the configured root "${fs.realpathSync(root)}".`,
     );

--- a/apps/open-swe/src/server/routes/run.ts
+++ b/apps/open-swe/src/server/routes/run.ts
@@ -1,13 +1,14 @@
 import type { Hono } from "hono";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
 import { resolveWorkspacePath } from "../../utils/workspace.js";
 import { createLogger, LogLevel } from "../../utils/logger.js";
 
 const logger = createLogger(LogLevel.INFO, "RunRoute");
 
 class RunConfigurationError extends Error {
-  public readonly status: number;
+  public readonly status: ContentfulStatusCode;
 
-  constructor(message: string, status: number) {
+  constructor(message: string, status: ContentfulStatusCode) {
     super(message);
     this.status = status;
   }
@@ -53,7 +54,7 @@ export function registerRunRoute(app: Hono) {
             error instanceof Error ? error.message : error,
           )}.`,
         },
-        400,
+        400 as ContentfulStatusCode,
       );
     }
 

--- a/apps/open-swe/src/tools/builtin-tools/handlers.ts
+++ b/apps/open-swe/src/tools/builtin-tools/handlers.ts
@@ -18,7 +18,7 @@ interface ViewCommandInputs {
 }
 
 export async function handleViewCommand(
-  sandbox: Sandbox,
+  sandbox: Sandbox | null,
   config: GraphConfig,
   inputs: ViewCommandInputs,
 ): Promise<string> {
@@ -55,6 +55,12 @@ export async function handleViewCommand(
       }
 
       return lines.map((line, index) => `${index + 1}: ${line}`).join("\n");
+    }
+
+    if (!sandbox) {
+      throw new Error(
+        "Sandbox session is required when workspace filesystem is unavailable.",
+      );
     }
 
     // Check if path is a directory
@@ -130,7 +136,7 @@ interface StrReplaceCommandInputs {
 }
 
 export async function handleStrReplaceCommand(
-  sandbox: Sandbox,
+  sandbox: Sandbox | null,
   config: GraphConfig,
   inputs: StrReplaceCommandInputs,
 ): Promise<string> {
@@ -164,6 +170,12 @@ export async function handleStrReplaceCommand(
     await fs.writeFile(targetPath, newContent, "utf-8");
     await stageAndCommitWorkspaceChanges(workspacePath);
     return `Successfully replaced text in ${inputs.path} at exactly one location.`;
+  }
+
+  if (!sandbox) {
+    throw new Error(
+      "Sandbox session is required when workspace filesystem is unavailable.",
+    );
   }
 
   const { path, workDir, oldStr, newStr } = inputs;
@@ -221,7 +233,7 @@ interface CreateCommandInputs {
 }
 
 export async function handleCreateCommand(
-  sandbox: Sandbox,
+  sandbox: Sandbox | null,
   config: GraphConfig,
   inputs: CreateCommandInputs,
 ): Promise<string> {
@@ -244,6 +256,12 @@ export async function handleCreateCommand(
     await fs.writeFile(targetPath, inputs.fileText, "utf-8");
     await stageAndCommitWorkspaceChanges(workspacePath);
     return `Successfully created file ${inputs.path}.`;
+  }
+
+  if (!sandbox) {
+    throw new Error(
+      "Sandbox session is required when workspace filesystem is unavailable.",
+    );
   }
 
   const { path, workDir, fileText } = inputs;
@@ -283,7 +301,7 @@ interface InsertCommandInputs {
 }
 
 export async function handleInsertCommand(
-  sandbox: Sandbox,
+  sandbox: Sandbox | null,
   config: GraphConfig,
   inputs: InsertCommandInputs,
 ): Promise<string> {
@@ -301,6 +319,12 @@ export async function handleInsertCommand(
     await fs.writeFile(targetPath, lines.join("\n"), "utf-8");
     await stageAndCommitWorkspaceChanges(workspacePath);
     return `Successfully inserted text in ${inputs.path} at line ${inputs.insertLine}.`;
+  }
+
+  if (!sandbox) {
+    throw new Error(
+      "Sandbox session is required when workspace filesystem is unavailable.",
+    );
   }
 
   const { path, workDir, insertLine, newStr } = inputs;


### PR DESCRIPTION
## Summary
- update the run route to use Hono's ContentfulStatusCode typings when returning errors
- allow text editing handlers to accept a null sandbox handle when operating on the workspace filesystem
- tighten the run route tests by asserting JSON payload shapes

## Testing
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_68d5a4056a3483279c90faa4b95b6a47