### PR TITLE
Ensure sandbox-docker builds after sandbox-core

### DIFF
--- a/packages/sandbox-core/tsconfig.json
+++ b/packages/sandbox-core/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "composite": true
   },
   "include": ["src/**/*.ts"],
   "exclude": ["dist", "node_modules"]

--- a/packages/sandbox-docker/package.json
+++ b/packages/sandbox-docker/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "clean": "rm -rf ./dist .turbo || true",
-    "build": "yarn clean && tsc -p tsconfig.json"
+    "build": "yarn clean && tsc -b tsconfig.json"
   },
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/sandbox-docker/tsconfig.json
+++ b/packages/sandbox-docker/tsconfig.json
@@ -2,8 +2,10 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "composite": true
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["dist", "node_modules"]
+  "exclude": ["dist", "node_modules"],
+  "references": [{ "path": "../sandbox-core" }]
 }


### PR DESCRIPTION
## Summary
- enable project references for the sandbox-core TypeScript project so it can be built as a dependency
- update the sandbox-docker TypeScript config to reference sandbox-core and mark it composite
- run sandbox-docker builds through tsc --build so sandbox-core is compiled automatically

## Testing
- yarn workspace @openswe/sandbox-docker build

------
https://chatgpt.com/codex/tasks/task_e_68d6d96c473c8327b4089231aea42d87