### PR TITLE
Configure sandbox-core path fallbacks

### DIFF
--- a/apps/open-swe/tsconfig.json
+++ b/apps/open-swe/tsconfig.json
@@ -6,6 +6,7 @@
     "module": "NodeNext",
     "moduleResolution": "nodenext",
     "esModuleInterop": true,
+    "baseUrl": "../..",
     "noImplicitReturns": true,
     "declaration": true,
     "noFallthroughCasesInSwitch": true,
@@ -17,10 +18,13 @@
     "strict": true,
     "strictFunctionTypes": false,
     "outDir": "dist",
-    "rootDir": ".",
     "types": ["jest", "node"],
     "resolveJsonModule": true,
-    "isolatedModules": true
+    "isolatedModules": true,
+    "paths": {
+      "@openswe/sandbox-core": ["packages/sandbox-core/src/index.ts"],
+      "@openswe/sandbox-core/*": ["packages/sandbox-core/src/*"]
+    }
   },
   "include": ["**/*.ts", "**/*.js", "jest.setup.cjs"],
   "exclude": ["node_modules", "dist"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "module": "NodeNext",
     "moduleResolution": "nodenext",
     "esModuleInterop": true,
+    "baseUrl": ".",
     "noImplicitReturns": true,
     "declaration": true,
     "noFallthroughCasesInSwitch": true,
@@ -18,7 +19,11 @@
     "strictFunctionTypes": false,
     "outDir": "dist",
     "types": ["jest", "node"],
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "paths": {
+      "@openswe/sandbox-core": ["packages/sandbox-core/src/index.ts"],
+      "@openswe/sandbox-core/*": ["packages/sandbox-core/src/*"]
+    }
   },
   "include": ["**/*.ts"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary
- set the repository TypeScript baseUrl and sandbox-core path aliases so builds can fall back to source files when the dist output is missing
- add the same sandbox-core path aliases to apps/open-swe so its build resolves the workspace source files during fresh installs

## Testing
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_68d6f32cfc208327b04e09d13bde0ea1