### PR TITLE
Add sandbox docker path aliases

### DIFF
--- a/apps/open-swe/tsconfig.json
+++ b/apps/open-swe/tsconfig.json
@@ -23,7 +23,9 @@
     "isolatedModules": true,
     "paths": {
       "@openswe/sandbox-core": ["packages/sandbox-core/src/index.ts"],
-      "@openswe/sandbox-core/*": ["packages/sandbox-core/src/*"]
+      "@openswe/sandbox-core/*": ["packages/sandbox-core/src/*"],
+      "@openswe/sandbox-docker": ["packages/sandbox-docker/src/index.ts"],
+      "@openswe/sandbox-docker/*": ["packages/sandbox-docker/src/*"]
     }
   },
   "include": ["**/*.ts", "**/*.js", "jest.setup.cjs"],


### PR DESCRIPTION
## Summary
- add path aliases in the open-swe app tsconfig for the sandbox Docker package to expose its types

## Testing
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_68d6feb06ee88327a195927789eaef04