### PR TITLE
fix: update sandbox-core import paths

### DIFF
--- a/apps/open-swe/evals/tests.ts
+++ b/apps/open-swe/evals/tests.ts
@@ -7,7 +7,7 @@ import {
   RuffIssue,
   MyPyResult,
 } from "./open-swe-types.js";
-import { execInSandbox } from "@openswe/sandbox-core/runners";
+import { execInSandbox } from "@openswe/sandbox-core";
 
 const logger = createLogger(LogLevel.DEBUG, " Evaluation Tests");
 

--- a/apps/open-swe/langbench/utils.ts
+++ b/apps/open-swe/langbench/utils.ts
@@ -2,7 +2,7 @@ import { createLogger, LogLevel } from "../src/utils/logger.js";
 import { ENV_CONSTANTS } from "../src/utils/env-setup.js";
 import { TestResults, PytestJsonReport, RunPytestOptions } from "./types.js";
 import { readFile } from "../src/utils/read-write.js";
-import { execInSandbox, runPythonTests } from "@openswe/sandbox-core/runners";
+import { execInSandbox, runPythonTests } from "@openswe/sandbox-core";
 
 const logger = createLogger(LogLevel.DEBUG, "Langbench Utils");
 

--- a/apps/open-swe/src/utils/env-setup.ts
+++ b/apps/open-swe/src/utils/env-setup.ts
@@ -1,7 +1,7 @@
 import type { Sandbox } from "./sandbox.js";
 import { createLogger, LogLevel } from "./logger.js";
 import { TIMEOUT_SEC } from "@openswe/shared/constants";
-import { execInSandbox } from "@openswe/sandbox-core/runners";
+import { execInSandbox } from "@openswe/sandbox-core";
 
 const logger = createLogger(LogLevel.INFO, "EnvSetup");
 


### PR DESCRIPTION
## Summary
- update the open-swe agent utilities to import sandbox helpers from the workspace root entrypoint

## Testing
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_68d6ff9669c08327b0fa464b55c25c18