### PR TITLE
Restore web service while using local image build

### DIFF
--- a/compose.local.yaml
+++ b/compose.local.yaml
@@ -55,7 +55,7 @@ services:
       - ${WORKSPACES_ROOT:-.}:/workspaces:delegated
       - /var/run/docker.sock:/var/run/docker.sock
 
-  ui:
+  web:
     build: *openswe-build
     image: open-swe:local
     command: ["yarn", "workspace", "@openswe/web", "dev"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,24 @@
+x-open-swe-build: &openswe-build
+  context: .
+  dockerfile: Dockerfile
+
 services:
-  open-swe:
-    build:
-      context: .
-    image: open-swe:latest
+  agent:
+    build: *openswe-build
+    image: open-swe:local
     command: ["yarn", "workspace", "@openswe/agent", "dev"]
     environment:
       - NODE_ENV=production
     ports:
       - "2024:2024"
+
   web:
-    image: open-swe:latest
+    build: *openswe-build
+    image: open-swe:local
     command: ["yarn", "workspace", "@openswe/web", "start"]
     environment:
       - NODE_ENV=production
     ports:
       - "3000:3000"
     depends_on:
-      - open-swe
+      - agent


### PR DESCRIPTION
## Summary
- rename the service back to `web` in both compose files so the UI is exposed under the expected name
- keep the local build anchor and `open-swe:local` image tag to avoid pulling the remote image

## Testing
- `docker compose -f docker-compose.yml -f compose.local.yaml config` *(fails in this environment because Docker is unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68dffaab13088327a667b9e698f375d5