### PR TITLE
Deduplicate Docker bind mounts in sandbox provider

### DIFF
--- a/apps/open-swe/src/__tests__/local-docker-sandbox-provider.test.ts
+++ b/apps/open-swe/src/__tests__/local-docker-sandbox-provider.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "@jest/globals";
+import { dedupeBindsPreferRW } from "@openswe/sandbox-docker";
+
+describe("dedupeBindsPreferRW", () => {
+  it("prefers rw entries when the same container target is mounted multiple times", () => {
+    const binds = [
+      "/host/a:/workspace/src:ro",
+      "/host/b:/workspace/src:rw",
+    ];
+
+    expect(dedupeBindsPreferRW(binds)).toEqual(["/host/b:/workspace/src:rw"]);
+  });
+
+  it("preserves order while normalizing container paths when replacing ro with rw", () => {
+    const binds = [
+      "/host/a:/workspace/src/:ro",
+      "/host/b:/workspace/data:ro",
+      "/host/c:/workspace/src:rw",
+    ];
+
+    expect(dedupeBindsPreferRW(binds)).toEqual([
+      "/host/c:/workspace/src:rw",
+      "/host/b:/workspace/data:ro",
+    ]);
+  });
+
+  it("treats binds without an explicit mode as rw and keeps them over ro duplicates", () => {
+    const binds = [
+      "/host/a:/workspace/cache",
+      "/host/b:/workspace/cache:ro",
+    ];
+
+    expect(dedupeBindsPreferRW(binds)).toEqual(["/host/a:/workspace/cache"]);
+  });
+});

--- a/packages/sandbox-docker/src/index.ts
+++ b/packages/sandbox-docker/src/index.ts
@@ -1,4 +1,7 @@
-export { LocalDockerSandboxProvider } from "./LocalDockerSandboxProvider.js";
+export {
+  LocalDockerSandboxProvider,
+  dedupeBindsPreferRW,
+} from "./LocalDockerSandboxProvider.js";
 export type {
   LocalDockerSandboxOptions,
   LocalDockerSandboxResources,


### PR DESCRIPTION
## Summary
- add a helper to normalize and deduplicate Docker bind mounts while preferring rw access
- apply the helper when creating local Docker sandboxes to avoid duplicate container targets
- cover the new behavior with unit tests exercising duplicate container paths and rw precedence

## Testing
- yarn turbo run test --filter=@openswe/agent

------
https://chatgpt.com/codex/tasks/task_e_68e03efd0f9083279f6394e29eb5c0ba