### PR TITLE
Fix sandbox-docker build type inference error

### DIFF
--- a/packages/sandbox-docker/src/LocalDockerSandboxProvider.ts
+++ b/packages/sandbox-docker/src/LocalDockerSandboxProvider.ts
@@ -68,7 +68,7 @@ export const dedupeBindsPreferRW = (binds: string[]): string[] => {
       rawContainer === "" || rawContainer === "/"
         ? rawContainer
         : rawContainer.replace(/\/+$/, "");
-    const effectiveMode = mode ?? RW_MODE;
+    const effectiveMode: BindMode = mode ?? RW_MODE;
     const normalizedBind = container === "" ? bind : (() => {
       const bindParts: string[] = [];
       if (host !== "" || bind.startsWith(":")) {


### PR DESCRIPTION
## Summary
- annotate the effective bind mode to satisfy strict TypeScript inference in LocalDockerSandboxProvider

## Testing
- yarn build --filter=@openswe/sandbox-docker

------
https://chatgpt.com/codex/tasks/task_e_68e041ab35ec8327a8cc083a7b2e5daa